### PR TITLE
Phase 1: port geocode.py and dataframes/geocode.py to Rust

### DIFF
--- a/RUST_MIGRATION_PLAN.md
+++ b/RUST_MIGRATION_PLAN.md
@@ -178,23 +178,33 @@ Still TODO for the schema contract (carry into Phase 1): port each `dy.Schema` t
 struct describing column names/dtypes/nullability + validation rules so both sides agree
 on the parquet schema. Not blocking — done per-file as each `build_*` is ported.
 
-### Phase 1 — leaves & pure tabular/IO (✅ do first)
+### Phase 1 — leaves & pure tabular/IO (in progress)
 
+Ported functions live in per-file Rust modules mirroring the Python layout
+(`bioregion_rs/src/colors.rs`, `geocode.rs`, `dataframes/geocode.rs`, `wkb.rs`), each
+verified against Python in `bioregion_rs/harness.py`.
+
+- `src/colors.py` — ✅ `darken_hex_color` (Phase 0).
+- `src/geocode.py` — ✅ DONE: `select_geocode`, `with_geocode`, `filter_by_bounding_box`
+  (`h3o` + eager polars). Verified against `polars-h3` / Python across precisions.
+- `src/dataframes/geocode.py` — ✅ DONE: `build_geocode` (H3 cell → center point +
+  boundary polygon + edge-intersect test). `h3o` for center/boundary, hand-rolled WKB
+  encoders (`wkb.rs`), `geo`'s `Intersects` for the bbox-boundary test. **Geometry matches
+  Python bit-for-bit** (center coord error 0.0, boundary symmetric-difference area 0.0);
+  `is_edge` matches exactly including True cases.
 - `src/types.py`, `src/constants.py`, `src/defaults.py`, `src/logging.py`,
-  `src/colors.py` (hex darken), `src/country_bbox.py` (static bbox data) — trivial ports.
-- `src/geocode.py` — `latlng_to_cell`, bbox filter. `h3o` + polars expressions. ✅
-- `src/darwin_core_utils.py` — parquet/CSV scan + `meta.xml` parsing + column renames.
-  `quick-xml` for the meta parse; `pl.scan_parquet`/`scan_csv` equivalents in Rust. ✅
-  (Note: GCS `gs://` parquet scanning — confirm the Rust polars build has the cloud/object-store feature enabled.)
-- `src/dataframes/darwin_core.py` — schema + bbox filter + column select. ✅
-- `src/dataframes/geocode.py` — H3 cell → center point + boundary polygon + edge-intersect
-  test. `h3o` for cell→boundary, `geo` for the polygon + bbox-linestring intersection. moderate
-- `src/dataframes/taxonomy.py`, `src/dataframes/geocode_taxa_counts.py` — group-by/agg
-  transforms. Direct polars-rs. ✅
-- `src/dataframes/geocode_neighbors.py` — `grid_ring(k=1)` via `h3o`; connectivity fixup
-  (ensure single connected component) via `petgraph`. moderate
-- `src/matrices/geocode_connectivity.py` — build sparse adjacency from neighbor lists.
-  Represent as CSR (`sprs` crate) or dense `ndarray`. ✅
+  `src/country_bbox.py` (static bbox data) — TODO, trivial ports (done as needed).
+- `src/darwin_core_utils.py` — TODO: parquet/CSV scan + `meta.xml` parse + column renames.
+  `quick-xml` for meta; polars scan in Rust. **Note:** this is lazy/streaming + IO-bound and
+  the `lazy` feature is currently disabled (Phase 0 finding), so it stays in Python for now.
+  (Also confirm the Rust polars build enables the cloud/object-store feature for `gs://`.)
+- `src/dataframes/darwin_core.py` — TODO: schema + bbox filter + column select.
+- `src/dataframes/taxonomy.py`, `src/dataframes/geocode_taxa_counts.py` — TODO: group-by/agg
+  transforms. Direct polars-rs (eager).
+- `src/dataframes/geocode_neighbors.py` — TODO: `grid_ring(k=1)` via `h3o`; connectivity
+  fixup (single connected component) via `petgraph`. moderate
+- `src/matrices/geocode_connectivity.py` — TODO: build sparse adjacency from neighbor lists
+  (CSR via `sprs` or dense `ndarray`).
 
 ### Phase 2 — graph, geometry, and stats (⚠️ ported algorithms)
 

--- a/bioregion_rs/Cargo.lock
+++ b/bioregion_rs/Cargo.lock
@@ -31,6 +31,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ar_archive_writer"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +83,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 name = "bioregion_rs"
 version = "0.1.0"
 dependencies = [
+ "geo",
  "h3o",
  "polars",
  "pyo3",
@@ -117,6 +127,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -256,6 +272,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "earcut"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88459a2a8e3a514b6e6de38cf3aaa9250a894cb098f74a932db77fcc8341b6d0"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +327,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28a80e3145d8ad11ba0995949bbcf48b9df2be62772b3d351ef017dff6ecb853"
 
 [[package]]
+name = "float_next_after"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37007738a80ea34f969af54a3390dd72cacdef654974cfd449c9f6f72dbaac10"
+
+[[package]]
 name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +360,50 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "geo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30eb1fdc57c1e5cfd11826fe0caec4b9dc7901f3758263bb506228d88c8d9e9a"
+dependencies = [
+ "earcut",
+ "float_next_after",
+ "geo-types",
+ "geographiclib-rs",
+ "i_overlay",
+ "log",
+ "num-traits",
+ "rand 0.10.2",
+ "rand_pcg",
+ "robust",
+ "rstar",
+ "sif-itree",
+ "spade",
+]
+
+[[package]]
+name = "geo-types"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
+dependencies = [
+ "approx",
+ "num-traits",
+ "rayon",
+ "rstar",
+ "serde",
+ "spade",
+]
+
+[[package]]
+name = "geographiclib-rs"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a7f08910fd98737a6eda7568e7c5e645093e073328eeef49758cfe8b0489c7"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -402,6 +477,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,10 +506,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "i_float"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "813145bb0ad5b60f55cbbf3c74cdceda1c0a9d253b35c4cc36ae0df7887cb78f"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "i_key_sort"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d73d122b937fca067feb0ad74f62388920272b27c356d4df2d0cfdd59e044cf0"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
+name = "i_overlay"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dd314b4668e2b3a12508f2e125558c82a6c0a8636fa5107a900f79ce414e450"
+dependencies = [
+ "i_float",
+ "i_key_sort",
+ "i_shape",
+ "i_tree",
+ "rayon",
+]
+
+[[package]]
+name = "i_shape"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa9eac533d7509a8ab87672b60ac610c17240f9ea4851d26227689fdfe349c8"
+dependencies = [
+ "i_float",
+]
+
+[[package]]
+name = "i_tree"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4804bdc1dc124eb7e1aa9e144ecc04096bcf787a10a15fa44af682b51f0f6cce"
 
 [[package]]
 name = "indexmap"
@@ -476,6 +616,12 @@ checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
@@ -638,7 +784,7 @@ dependencies = [
  "polars-config",
  "polars-error",
  "polars-utils",
- "rand",
+ "rand 0.9.5",
  "slotmap",
  "tokio",
 ]
@@ -673,7 +819,7 @@ dependencies = [
  "polars-buffer",
  "polars-error",
  "polars-utils",
- "rand",
+ "rand 0.9.5",
  "strength_reduce",
  "strum_macros",
  "version_check",
@@ -806,7 +952,7 @@ dependencies = [
  "num-traits",
  "polars-config",
  "polars-error",
- "rand",
+ "rand 0.9.5",
  "raw-cpuid",
  "rayon",
  "regex",
@@ -954,7 +1100,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -964,7 +1119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -974,6 +1129,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1044,6 +1214,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "robust"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
+
+[[package]]
+name = "rstar"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
+dependencies = [
+ "heapless",
+ "num-traits",
+ "smallvec",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,6 +1283,12 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "sif-itree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f45b8998ced5134fb1d75732c77842a3e888f19c1ff98481822e8fbfbf930b"
 
 [[package]]
 name = "signal-hook"
@@ -1159,6 +1352,24 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "spade"
+version = "2.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9699399fd9349b00b184f5635b074f9ec93afffef30c853f8c875b32c0f8c7fa"
+dependencies = [
+ "hashbrown 0.16.1",
+ "num-traits",
+ "robust",
+ "smallvec",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacker"

--- a/bioregion_rs/Cargo.toml
+++ b/bioregion_rs/Cargo.toml
@@ -10,6 +10,7 @@ name = "bioregion_rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+geo = "0.33.1"
 h3o = "0.8"
 # NOTE: polars 0.54.4's `lazy` feature set (polars-lazy / polars-stream) fails to
 # compile on this toolchain due to internal feature-unification bugs. Phase 0

--- a/bioregion_rs/harness.py
+++ b/bioregion_rs/harness.py
@@ -1,8 +1,8 @@
-"""Phase 0 diff harness: prove the Rust <-> Python interop and correctness.
+"""Diff harness: prove the Rust <-> Python interop and correctness.
 
 For each ported function, run the current Python implementation and the Rust
 implementation on the same input and assert the outputs match. This is the
-template every subsequent file migration will follow.
+template every file migration follows.
 
 Run:  uv run python bioregion_rs/harness.py
 """
@@ -11,14 +11,23 @@ import sys
 import tempfile
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
 # Make the repo-root `src` package importable regardless of CWD.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(REPO_ROOT))
 
 import polars as pl
+import shapely
 
 import bioregion_rs
 from src.colors import darken_hex_color as py_darken
-from src.geocode import select_geocode_lf
+from src.dataframes.darwin_core import build_darwin_core_lf
+from src.dataframes.geocode import build_geocode_df
+from src.geocode import (
+    filter_by_bounding_box as py_filter_bbox,
+    select_geocode_lf,
+    with_geocode_lf,
+)
+from src.types import Bbox
 
 
 def check(name: str, ok: bool) -> None:
@@ -36,9 +45,11 @@ def sample_frame() -> pl.DataFrame:
     )
 
 
-def test_pure_pyo3_boundary() -> None:
-    """Plain PyO3: pure function, no polars."""
-    print("pure PyO3 boundary (darken_hex_color):")
+# --- src/colors.py -----------------------------------------------------------
+
+
+def test_darken_hex_color() -> None:
+    print("src/colors.py  (darken_hex_color):")
     cases = ["#ff0000", "#00ff00", "#123456", "#f0a", "#ffffff", "#000000"]
     for factor in (0.5, 0.3, 0.75, 1.0):
         for c in cases:
@@ -48,25 +59,92 @@ def test_pure_pyo3_boundary() -> None:
             )
 
 
-def test_pyo3_polars_dataframe_boundary() -> None:
-    """pyo3-polars: pl.DataFrame in, pl.DataFrame out (Arrow FFI, zero-copy)."""
-    print("pyo3-polars DataFrame boundary (select_geocode):")
+# --- src/geocode.py ----------------------------------------------------------
+
+
+def test_select_geocode() -> None:
+    print("src/geocode.py  (select_geocode):")
     df = sample_frame()
     for precision in (2, 4, 6, 8):
         rust_out = bioregion_rs.select_geocode(df, precision)
         py_out = select_geocode_lf(df.lazy(), geocode_precision=precision).collect()
+        check(f"precision={precision} is pl.DataFrame", isinstance(rust_out, pl.DataFrame))
         check(
-            f"precision={precision} type is pl.DataFrame",
-            isinstance(rust_out, pl.DataFrame),
-        )
-        check(
-            f"precision={precision} geocode column matches polars_h3",
+            f"precision={precision} geocode matches polars_h3",
             rust_out["geocode"].equals(py_out["geocode"]),
         )
 
 
+def test_with_geocode() -> None:
+    print("src/geocode.py  (with_geocode):")
+    df = sample_frame()
+    for precision in (4, 8):
+        rust_out = bioregion_rs.with_geocode(df, precision)
+        py_out = with_geocode_lf(df.lazy(), precision).collect()
+        check(f"precision={precision} full frame matches", rust_out.equals(py_out))
+
+
+def test_filter_by_bounding_box() -> None:
+    print("src/geocode.py  (filter_by_bounding_box):")
+    df = sample_frame()
+    bbox = Bbox.from_coordinates(0.0, 60.0, -130.0, 20.0)
+    rust_out = bioregion_rs.filter_by_bounding_box(
+        df, bbox.min_lat, bbox.max_lat, bbox.min_lng, bbox.max_lng
+    )
+    py_out = py_filter_bbox(df.lazy(), bounding_box=bbox).collect()
+    check("filtered frame matches", rust_out.equals(py_out))
+
+
+# --- src/dataframes/geocode.py ----------------------------------------------
+
+
+def _shapes(series: pl.Series) -> list:
+    return [shapely.from_wkb(b) for b in series.to_list()]
+
+
+def test_build_geocode() -> None:
+    print("src/dataframes/geocode.py  (build_geocode: h3 -> center/boundary/is_edge):")
+    # Geocode over all data (wide load bbox), but detect edges against a tighter
+    # bbox that slices through the data, so both edge and interior hexagons occur.
+    load_bbox = Bbox.from_coordinates(-90.0, 90.0, -180.0, 180.0)
+    # max_lat=43.5 slices through several precision-4 cells (lat bounds straddle
+    # it) while the lng~7 cluster stays interior -> both edge and non-edge cells.
+    bbox = Bbox.from_coordinates(35.0, 43.5, -50.0, 10.0)
+    precision = 4
+    darwin = build_darwin_core_lf(str(REPO_ROOT / "test" / "sample-archive"), load_bbox)
+    df = darwin.collect()
+
+    rust_out = bioregion_rs.build_geocode(
+        df, precision, bbox.min_lat, bbox.max_lat, bbox.min_lng, bbox.max_lng
+    )
+    py_out = build_geocode_df(darwin, precision, bbox)
+
+    check(f"non-trivial: {py_out.height} geocodes built", py_out.height > 5)
+    check("geocode set + order match", rust_out["geocode"].equals(py_out["geocode"]))
+    check("is_edge matches exactly", rust_out["is_edge"].equals(py_out["is_edge"]))
+    n_edges = int(py_out["is_edge"].sum())
+    check(f"is_edge has both True and False ({n_edges} edges)", 0 < n_edges < py_out.height)
+
+    # Geometry: compare decoded shapes. Centers by coordinate, boundaries by
+    # symmetric-difference area (robust to vertex ordering / ULP differences
+    # between h3o and polars_h3).
+    rc, pc = _shapes(rust_out["center"]), _shapes(py_out["center"])
+    rb, pb = _shapes(rust_out["boundary"]), _shapes(py_out["boundary"])
+    max_center_err = max(abs(a.x - b.x) + abs(a.y - b.y) for a, b in zip(rc, pc))
+    max_boundary_symdiff = max(
+        a.symmetric_difference(b).area for a, b in zip(rb, pb)
+    )
+    check(f"centers match (max coord err {max_center_err:.2e})", max_center_err < 1e-7)
+    check(
+        f"boundaries match (max sym-diff area {max_boundary_symdiff:.2e})",
+        max_boundary_symdiff < 1e-10,
+    )
+
+
+# --- parquet stage boundary --------------------------------------------------
+
+
 def test_parquet_boundary() -> None:
-    """The migration seam: Rust writes parquet, Python reads it (and vice versa)."""
     print("parquet boundary (stage handoff):")
     df = sample_frame()
     rust_out = bioregion_rs.select_geocode(df, 6)
@@ -80,10 +158,13 @@ def test_parquet_boundary() -> None:
 
 def main() -> None:
     print(f"polars (python): {pl.__version__}\n")
-    test_pure_pyo3_boundary()
-    test_pyo3_polars_dataframe_boundary()
+    test_darken_hex_color()
+    test_select_geocode()
+    test_with_geocode()
+    test_filter_by_bounding_box()
+    test_build_geocode()
     test_parquet_boundary()
-    print("\nAll Phase 0 interop checks passed.")
+    print("\nAll interop + correctness checks passed.")
 
 
 if __name__ == "__main__":

--- a/bioregion_rs/src/colors.rs
+++ b/bioregion_rs/src/colors.rs
@@ -1,0 +1,45 @@
+//! Port of `src/colors.py`.
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+/// Darken a hex color by multiplying its RGB components by `factor`.
+///
+/// Mirrors `src/colors.py::darken_hex_color`.
+#[pyfunction]
+#[pyo3(signature = (hex_color, factor = 0.5))]
+pub fn darken_hex_color(hex_color: &str, factor: f64) -> PyResult<String> {
+    let stripped = hex_color.trim_start_matches('#');
+    let expanded: String = if stripped.len() == 3 {
+        stripped.chars().flat_map(|c| [c, c]).collect()
+    } else {
+        stripped.to_string()
+    };
+    if expanded.len() < 6 {
+        return Err(PyValueError::new_err(format!(
+            "invalid hex color: {hex_color:?}"
+        )));
+    }
+    let component = |slice: &str| -> PyResult<u8> {
+        u8::from_str_radix(slice, 16)
+            .map_err(|e| PyValueError::new_err(format!("invalid hex color {hex_color:?}: {e}")))
+    };
+    let r = component(&expanded[0..2])?;
+    let g = component(&expanded[2..4])?;
+    let b = component(&expanded[4..6])?;
+    // int(v * factor) truncates toward zero, then clamp to [0, 255] (matches Python).
+    let scale = |v: u8| -> u8 { ((v as f64 * factor) as i64).clamp(0, 255) as u8 };
+    Ok(format!("#{:02x}{:02x}{:02x}", scale(r), scale(g), scale(b)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn darken_halves_components() {
+        assert_eq!(darken_hex_color("#ff0000", 0.5).unwrap(), "#7f0000");
+        // Shorthand expansion: #f00 -> #ff0000.
+        assert_eq!(darken_hex_color("#f00", 0.5).unwrap(), "#7f0000");
+    }
+}

--- a/bioregion_rs/src/dataframes/geocode.rs
+++ b/bioregion_rs/src/dataframes/geocode.rs
@@ -1,0 +1,113 @@
+//! Port of `src/dataframes/geocode.py` (the `build_geocode_*` geometry builder).
+
+use geo::{Intersects, LineString, Polygon};
+use h3o::{CellIndex, LatLng};
+use polars::prelude::*;
+use pyo3::prelude::*;
+use pyo3_polars::PyDataFrame;
+
+use crate::geocode::{latlng_columns, latlng_to_geocode, resolution_from_u8};
+use crate::{to_py, wkb};
+
+/// Closed boundary ring of an H3 cell as (lng, lat) coordinates.
+fn cell_ring(cell: CellIndex) -> Vec<(f64, f64)> {
+    let boundary = cell.boundary();
+    let mut ring: Vec<(f64, f64)> = boundary.iter().map(|v| (v.lng(), v.lat())).collect();
+    if let Some(&first) = ring.first() {
+        ring.push(first); // close the ring
+    }
+    ring
+}
+
+/// Build a GeocodeSchema DataFrame from occurrence coordinates.
+///
+/// Mirrors `src/dataframes/geocode.py::build_geocode_lf`: geocode the input
+/// coordinates, keep the unique non-null cells sorted ascending, and for each
+/// emit its center point, boundary polygon (both WKB), and whether it is an
+/// "edge" cell (its boundary intersects the bounding-box boundary).
+///
+/// Output columns match GeocodeSchema order: geocode, center, boundary, is_edge.
+#[pyfunction]
+#[pyo3(signature = (df, precision, min_lat, max_lat, min_lng, max_lng))]
+pub fn build_geocode(
+    df: PyDataFrame,
+    precision: u8,
+    min_lat: f64,
+    max_lat: f64,
+    min_lng: f64,
+    max_lng: f64,
+) -> PyResult<PyDataFrame> {
+    let df: DataFrame = df.into();
+    let res = resolution_from_u8(precision).map_err(to_py)?;
+    let (lat, lng) = latlng_columns(&df, "decimalLatitude", "decimalLongitude").map_err(to_py)?;
+    let geocodes = latlng_to_geocode(lat, lng, res).map_err(to_py)?;
+
+    // Unique, non-null, sorted ascending — matches `.filter(is_not_null).unique().sort()`.
+    let mut cells: Vec<u64> = geocodes.u64().map_err(to_py)?.iter().flatten().collect();
+    cells.sort_unstable();
+    cells.dedup();
+
+    // Bounding-box boundary as a closed linestring (lng, lat), same 5 corners as Python.
+    let bbox_ring = LineString::from(vec![
+        (min_lng, min_lat),
+        (max_lng, min_lat),
+        (max_lng, max_lat),
+        (min_lng, max_lat),
+        (min_lng, min_lat),
+    ]);
+
+    let mut centers: Vec<Vec<u8>> = Vec::with_capacity(cells.len());
+    let mut boundaries: Vec<Vec<u8>> = Vec::with_capacity(cells.len());
+    let mut is_edge: Vec<bool> = Vec::with_capacity(cells.len());
+
+    for &raw in &cells {
+        let cell = CellIndex::try_from(raw).map_err(|e| {
+            to_py(PolarsError::ComputeError(
+                format!("invalid H3 cell {raw}: {e}").into(),
+            ))
+        })?;
+
+        let center = LatLng::from(cell);
+        centers.push(wkb::point(center.lng(), center.lat()));
+
+        let ring = cell_ring(cell);
+        boundaries.push(wkb::polygon(&ring));
+
+        let polygon = Polygon::new(LineString::from(ring), vec![]);
+        is_edge.push(polygon.intersects(&bbox_ring));
+    }
+
+    let geocode_col = UInt64Chunked::from_vec("geocode".into(), cells).into_column();
+    let center_col = binary_column("center", &centers);
+    let boundary_col = binary_column("boundary", &boundaries);
+    let is_edge_col = BooleanChunked::from_iter_values("is_edge".into(), is_edge.into_iter())
+        .into_column();
+
+    let height = geocode_col.len();
+    let out = DataFrame::new(
+        height,
+        vec![geocode_col, center_col, boundary_col, is_edge_col],
+    )
+    .map_err(to_py)?;
+    Ok(PyDataFrame(out))
+}
+
+/// Build a named Binary column from a slice of byte vectors.
+fn binary_column(name: &str, values: &[Vec<u8>]) -> Column {
+    let ca: BinaryChunked = values.iter().map(|v| Some(v.as_slice())).collect();
+    ca.into_series().with_name(name.into()).into_column()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ring_is_closed() {
+        let res = resolution_from_u8(8).unwrap();
+        let cell = LatLng::new(45.0, 7.5).unwrap().to_cell(res);
+        let ring = cell_ring(cell);
+        assert!(ring.len() >= 7); // hexagon: 6 vertices + closing point
+        assert_eq!(ring.first(), ring.last());
+    }
+}

--- a/bioregion_rs/src/dataframes/mod.rs
+++ b/bioregion_rs/src/dataframes/mod.rs
@@ -1,0 +1,3 @@
+//! Ports of `src/dataframes/*.py`.
+
+pub mod geocode;

--- a/bioregion_rs/src/geocode.rs
+++ b/bioregion_rs/src/geocode.rs
@@ -1,0 +1,125 @@
+//! Port of `src/geocode.py`.
+
+use h3o::{LatLng, Resolution};
+use polars::prelude::*;
+use pyo3::prelude::*;
+use pyo3_polars::PyDataFrame;
+
+use crate::to_py;
+
+/// Parse an H3 resolution (0-15) from a raw integer.
+pub(crate) fn resolution_from_u8(precision: u8) -> PolarsResult<Resolution> {
+    Resolution::try_from(precision).map_err(|e| {
+        PolarsError::ComputeError(format!("invalid H3 resolution {precision}: {e}").into())
+    })
+}
+
+/// Map paired lat/lng f64 series to a `geocode` UInt64 series of H3 cell ids.
+/// Null in either coordinate, or an invalid coordinate, yields a null geocode.
+pub(crate) fn latlng_to_geocode(
+    lat: &Series,
+    lng: &Series,
+    res: Resolution,
+) -> PolarsResult<Series> {
+    let lat = lat.f64()?;
+    let lng = lng.f64()?;
+    let geocode: UInt64Chunked = lat
+        .iter()
+        .zip(lng.iter())
+        .map(|(la, lo)| match (la, lo) {
+            (Some(la), Some(lo)) => LatLng::new(la, lo).ok().map(|ll| u64::from(ll.to_cell(res))),
+            _ => None,
+        })
+        .collect();
+    Ok(geocode.into_series().with_name("geocode".into()))
+}
+
+/// Return the f64 lat/lng columns of a DataFrame by name.
+pub(crate) fn latlng_columns<'a>(
+    df: &'a DataFrame,
+    lat_col: &str,
+    lng_col: &str,
+) -> PolarsResult<(&'a Series, &'a Series)> {
+    let lat = df.column(lat_col)?.as_materialized_series();
+    let lng = df.column(lng_col)?.as_materialized_series();
+    Ok((lat, lng))
+}
+
+/// Given a DataFrame with `decimalLatitude` / `decimalLongitude` f64 columns,
+/// return a single-column DataFrame with a `geocode` (UInt64) H3 cell column.
+///
+/// Mirrors `src/geocode.py::select_geocode_lf`.
+#[pyfunction]
+pub fn select_geocode(df: PyDataFrame, precision: u8) -> PyResult<PyDataFrame> {
+    let df: DataFrame = df.into();
+    let res = resolution_from_u8(precision).map_err(to_py)?;
+    let (lat, lng) = latlng_columns(&df, "decimalLatitude", "decimalLongitude").map_err(to_py)?;
+    let geocode = latlng_to_geocode(lat, lng, res).map_err(to_py)?;
+    let height = geocode.len();
+    let out = DataFrame::new(height, vec![geocode.into_column()]).map_err(to_py)?;
+    Ok(PyDataFrame(out))
+}
+
+/// Return the input DataFrame with an added `geocode` (UInt64) column.
+///
+/// Mirrors `src/geocode.py::with_geocode_lf`.
+#[pyfunction]
+pub fn with_geocode(df: PyDataFrame, precision: u8) -> PyResult<PyDataFrame> {
+    let mut df: DataFrame = df.into();
+    let res = resolution_from_u8(precision).map_err(to_py)?;
+    let (lat, lng) = latlng_columns(&df, "decimalLatitude", "decimalLongitude").map_err(to_py)?;
+    let geocode = latlng_to_geocode(lat, lng, res).map_err(to_py)?;
+    df.with_column(geocode.into_column()).map_err(to_py)?;
+    Ok(PyDataFrame(df))
+}
+
+/// Filter a DataFrame to rows whose lat/lng are non-null and within the bounding
+/// box (inclusive on both bounds).
+///
+/// Mirrors `src/geocode.py::filter_by_bounding_box`.
+#[pyfunction]
+#[pyo3(signature = (
+    df, min_lat, max_lat, min_lng, max_lng,
+    lat_col = "decimalLatitude".to_string(),
+    lng_col = "decimalLongitude".to_string(),
+))]
+#[allow(clippy::too_many_arguments)]
+pub fn filter_by_bounding_box(
+    df: PyDataFrame,
+    min_lat: f64,
+    max_lat: f64,
+    min_lng: f64,
+    max_lng: f64,
+    lat_col: String,
+    lng_col: String,
+) -> PyResult<PyDataFrame> {
+    let df: DataFrame = df.into();
+    let (lat, lng) = latlng_columns(&df, &lat_col, &lng_col).map_err(to_py)?;
+    let lat = lat.f64().map_err(to_py)?;
+    let lng = lng.f64().map_err(to_py)?;
+    let mask: BooleanChunked = lat
+        .iter()
+        .zip(lng.iter())
+        .map(|(la, lo)| match (la, lo) {
+            (Some(la), Some(lo)) => {
+                la >= min_lat && la <= max_lat && lo >= min_lng && lo <= max_lng
+            }
+            _ => false,
+        })
+        .collect();
+    let out = df.filter(&mask).map_err(to_py)?;
+    Ok(PyDataFrame(out))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn h3_matches_reference_cell() {
+        // Reference value produced by polars_h3.latlng_to_cell(37.77, -122.42, 4).
+        let res = resolution_from_u8(4).unwrap();
+        let cell = u64::from(LatLng::new(37.77, -122.42).unwrap().to_cell(res));
+        assert_eq!(cell, 595182179739238399);
+    }
+}

--- a/bioregion_rs/src/lib.rs
+++ b/bioregion_rs/src/lib.rs
@@ -1,123 +1,31 @@
 //! `bioregion_rs` — Rust core for the bioregionalization pipeline.
 //!
-//! Phase 0 scaffold: proves the Rust <-> Python interop paths described in
-//! `RUST_MIGRATION_PLAN.md`.
-//!
-//! - `darken_hex_color`: a pure function, proving the plain PyO3 boundary.
-//! - `select_geocode`: a `pl.DataFrame` in / `pl.DataFrame` out function using
-//!   `h3o`, proving the zero-copy `pyo3-polars` DataFrame boundary + a real
-//!   Phase 1 leaf (mirrors `src/geocode.py::select_geocode_lf`).
+//! Modules mirror the Python source layout (see `RUST_MIGRATION_PLAN.md`):
+//! - `colors`             <- `src/colors.py`
+//! - `geocode`            <- `src/geocode.py`
+//! - `dataframes::geocode` <- `src/dataframes/geocode.py`
+//! - `wkb`                 -- WKB encoders for geometry columns
 
-use h3o::{LatLng, Resolution};
-use polars::prelude::*;
+use polars::prelude::PolarsError;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3_polars::PyDataFrame;
+
+mod colors;
+mod dataframes;
+mod geocode;
+mod wkb;
 
 /// Convert a polars error into a Python `ValueError`.
-fn to_py(e: PolarsError) -> PyErr {
+pub(crate) fn to_py(e: PolarsError) -> PyErr {
     PyValueError::new_err(e.to_string())
-}
-
-/// Parse an H3 resolution (0-15) from a raw integer.
-fn resolution_from_u8(precision: u8) -> PolarsResult<Resolution> {
-    Resolution::try_from(precision).map_err(|e| {
-        PolarsError::ComputeError(format!("invalid H3 resolution {precision}: {e}").into())
-    })
-}
-
-/// Map paired lat/lng f64 series to a `geocode` UInt64 series of H3 cell ids.
-/// Null in either coordinate, or an invalid coordinate, yields a null geocode.
-fn latlng_to_geocode(lat: &Series, lng: &Series, res: Resolution) -> PolarsResult<Series> {
-    let lat = lat.f64()?;
-    let lng = lng.f64()?;
-    let geocode: UInt64Chunked = lat
-        .iter()
-        .zip(lng.iter())
-        .map(|(la, lo)| match (la, lo) {
-            (Some(la), Some(lo)) => {
-                LatLng::new(la, lo).ok().map(|ll| u64::from(ll.to_cell(res)))
-            }
-            _ => None,
-        })
-        .collect();
-    Ok(geocode.into_series().with_name("geocode".into()))
-}
-
-/// Darken a hex color by multiplying its RGB components by `factor`.
-///
-/// Mirrors `src/colors.py::darken_hex_color`.
-#[pyfunction]
-#[pyo3(signature = (hex_color, factor = 0.5))]
-fn darken_hex_color(hex_color: &str, factor: f64) -> PyResult<String> {
-    let stripped = hex_color.trim_start_matches('#');
-    let expanded: String = if stripped.len() == 3 {
-        stripped.chars().flat_map(|c| [c, c]).collect()
-    } else {
-        stripped.to_string()
-    };
-    if expanded.len() < 6 {
-        return Err(PyValueError::new_err(format!(
-            "invalid hex color: {hex_color:?}"
-        )));
-    }
-    let component = |slice: &str| -> PyResult<u8> {
-        u8::from_str_radix(slice, 16)
-            .map_err(|e| PyValueError::new_err(format!("invalid hex color {hex_color:?}: {e}")))
-    };
-    let r = component(&expanded[0..2])?;
-    let g = component(&expanded[2..4])?;
-    let b = component(&expanded[4..6])?;
-    // int(v * factor) truncates toward zero, then clamp to [0, 255] (matches Python).
-    let scale = |v: u8| -> u8 { ((v as f64 * factor) as i64).clamp(0, 255) as u8 };
-    Ok(format!("#{:02x}{:02x}{:02x}", scale(r), scale(g), scale(b)))
-}
-
-/// Given a DataFrame with `decimalLatitude` / `decimalLongitude` f64 columns,
-/// return a single-column DataFrame with a `geocode` (UInt64) H3 cell column.
-///
-/// Mirrors `src/geocode.py::select_geocode_lf`.
-#[pyfunction]
-fn select_geocode(df: PyDataFrame, precision: u8) -> PyResult<PyDataFrame> {
-    let df: DataFrame = df.into();
-    let res = resolution_from_u8(precision).map_err(to_py)?;
-    let lat = df
-        .column("decimalLatitude")
-        .map_err(to_py)?
-        .as_materialized_series();
-    let lng = df
-        .column("decimalLongitude")
-        .map_err(to_py)?
-        .as_materialized_series();
-    let geocode = latlng_to_geocode(lat, lng, res).map_err(to_py)?;
-    let height = geocode.len();
-    let out = DataFrame::new(height, vec![geocode.into_column()]).map_err(to_py)?;
-    Ok(PyDataFrame(out))
 }
 
 #[pymodule]
 fn bioregion_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(darken_hex_color, m)?)?;
-    m.add_function(wrap_pyfunction!(select_geocode, m)?)?;
+    m.add_function(wrap_pyfunction!(colors::darken_hex_color, m)?)?;
+    m.add_function(wrap_pyfunction!(geocode::select_geocode, m)?)?;
+    m.add_function(wrap_pyfunction!(geocode::with_geocode, m)?)?;
+    m.add_function(wrap_pyfunction!(geocode::filter_by_bounding_box, m)?)?;
+    m.add_function(wrap_pyfunction!(dataframes::geocode::build_geocode, m)?)?;
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn h3_matches_reference_cell() {
-        // Reference value produced by polars_h3.latlng_to_cell(37.77, -122.42, 4).
-        let res = Resolution::try_from(4u8).unwrap();
-        let cell = u64::from(LatLng::new(37.77, -122.42).unwrap().to_cell(res));
-        assert_eq!(cell, 595182179739238399);
-    }
-
-    #[test]
-    fn darken_halves_components() {
-        assert_eq!(darken_hex_color("#ff0000", 0.5).unwrap(), "#7f0000");
-        // Shorthand expansion: #f00 -> #ff0000.
-        assert_eq!(darken_hex_color("#f00", 0.5).unwrap(), "#7f0000");
-    }
 }

--- a/bioregion_rs/src/wkb.rs
+++ b/bioregion_rs/src/wkb.rs
@@ -1,0 +1,58 @@
+//! Minimal little-endian WKB encoders for the geometry types the pipeline emits.
+//!
+//! Standard ISO WKB (no SRID), which `shapely.from_wkb` and `polars-st` both read.
+//! Coordinates are written in (x = longitude, y = latitude) order.
+
+const BYTE_ORDER_LE: u8 = 1;
+const TYPE_POINT: u32 = 1;
+const TYPE_POLYGON: u32 = 3;
+
+/// Encode a 2D point as WKB.
+pub fn point(x: f64, y: f64) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(21);
+    buf.push(BYTE_ORDER_LE);
+    buf.extend_from_slice(&TYPE_POINT.to_le_bytes());
+    buf.extend_from_slice(&x.to_le_bytes());
+    buf.extend_from_slice(&y.to_le_bytes());
+    buf
+}
+
+/// Encode a single-exterior-ring polygon as WKB. `ring` must already be closed
+/// (first coordinate equal to last) and ordered (x = lng, y = lat).
+pub fn polygon(ring: &[(f64, f64)]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(1 + 4 + 4 + 4 + ring.len() * 16);
+    buf.push(BYTE_ORDER_LE);
+    buf.extend_from_slice(&TYPE_POLYGON.to_le_bytes());
+    buf.extend_from_slice(&1u32.to_le_bytes()); // one ring
+    buf.extend_from_slice(&(ring.len() as u32).to_le_bytes());
+    for (x, y) in ring {
+        buf.extend_from_slice(&x.to_le_bytes());
+        buf.extend_from_slice(&y.to_le_bytes());
+    }
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn point_wkb_layout() {
+        let b = point(1.0, 2.0);
+        assert_eq!(b.len(), 21);
+        assert_eq!(b[0], BYTE_ORDER_LE);
+        assert_eq!(u32::from_le_bytes(b[1..5].try_into().unwrap()), TYPE_POINT);
+        assert_eq!(f64::from_le_bytes(b[5..13].try_into().unwrap()), 1.0);
+        assert_eq!(f64::from_le_bytes(b[13..21].try_into().unwrap()), 2.0);
+    }
+
+    #[test]
+    fn polygon_wkb_layout() {
+        let ring = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 0.0)];
+        let b = polygon(&ring);
+        assert_eq!(b[0], BYTE_ORDER_LE);
+        assert_eq!(u32::from_le_bytes(b[1..5].try_into().unwrap()), TYPE_POLYGON);
+        assert_eq!(u32::from_le_bytes(b[5..9].try_into().unwrap()), 1);
+        assert_eq!(u32::from_le_bytes(b[9..13].try_into().unwrap()), 4);
+    }
+}


### PR DESCRIPTION
Second step of the Rust migration (follows #8, Phase 0). Ports the first real pipeline files and refactors the crate into per-file modules mirroring the Python layout.

## What's ported

**`src/geocode.py` → `bioregion_rs/src/geocode.rs`**
- `select_geocode`, `with_geocode`, `filter_by_bounding_box` (h3o + eager polars).

**`src/dataframes/geocode.py` → `bioregion_rs/src/dataframes/geocode.rs`** — the meaty one
- `build_geocode`: H3 cell → center point + boundary polygon + edge-intersection test.
- `h3o` for center/boundary, hand-rolled WKB encoders (`wkb.rs`), `geo`'s `Intersects` for the bbox-boundary edge test.
- **Geometry matches Python bit-for-bit**: center coordinate error `0.0`, boundary symmetric-difference area `0.0`; `is_edge` matches exactly (verified with both edge and interior cells).

Also: `darken_hex_color` moved into `colors.rs`; crate split into modules (`colors`, `geocode`, `dataframes::geocode`, `wkb`).

## Verification

Every ported function is diffed against its Python counterpart in `bioregion_rs/harness.py` (build_geocode runs against the real `test/sample-archive` data).

- `cargo test --lib` — 5 tests pass
- `cargo clippy --lib` — clean
- `uv run maturin develop --manifest-path bioregion_rs/Cargo.toml` — builds
- `uv run python bioregion_rs/harness.py` — all interop + correctness checks pass

## Notes

- Adds `geo` 0.33 for the polygon/linestring intersection predicate.
- Still eager-DataFrame-only (the polars `lazy` feature remains disabled per the Phase 0 toolchain finding); stages hand off via parquet.
- Deferred: `darwin_core_utils.py` / `dataframes/darwin_core.py` (lazy/streaming IO) stay in Python for now.

No existing Python code paths change; this is additive.