### PR TITLE
Phase 1: port taxonomy.py and geocode_taxa_counts.py to Rust

### DIFF
--- a/RUST_MIGRATION_PLAN.md
+++ b/RUST_MIGRATION_PLAN.md
@@ -199,8 +199,24 @@ verified against Python in `bioregion_rs/harness.py`.
   the `lazy` feature is currently disabled (Phase 0 finding), so it stays in Python for now.
   (Also confirm the Rust polars build enables the cloud/object-store feature for `gs://`.)
 - `src/dataframes/darwin_core.py` — TODO: schema + bbox filter + column select.
-- `src/dataframes/taxonomy.py`, `src/dataframes/geocode_taxa_counts.py` — TODO: group-by/agg
-  transforms. Direct polars-rs (eager).
+- `src/dataframes/taxonomy.py` — ✅ DONE: `build_taxonomy` (distinct
+  (scientificName, gbifTaxonId) pairs restricted to known geocodes, each assigned a
+  synthetic `taxonId`). Uses `DataFrame::group_by`/`unique`/`with_row_index` from
+  **`polars-core`** directly — no `polars-ops`/joins/`is_in` needed (semi-join and
+  dedup done as eager, hand-rolled filters, consistent with the no-`lazy` constraint).
+  Verified against Python by comparing the (scientificName, gbifTaxonId) pair set and
+  that `taxonId` is a 0..n bijection (row order — and thus which literal `taxonId` a
+  pair gets — is not guaranteed to match Python's `.unique()` ordering, only the set
+  and the bijection are).
+- `src/dataframes/geocode_taxa_counts.py` — ✅ DONE: `build_geocode_taxa_counts` (the
+  core `build_geocode_taxa_counts_lf` aggregation; `filter_top_taxa_lf` is deferred —
+  it's an optional scaling filter, not on the critical path). The Python join against
+  taxonomy (on scientificName+gbifTaxonId) and the group-by-sum are hand-rolled with a
+  `HashMap` lookup + `polars-core`'s (deprecated but functional) `GroupBy::sum`, for the
+  same reason as `taxonomy.rs` — no `polars-ops` dependency. Verified by resolving both
+  engines' output back through their own taxonomy to (geocode, scientificName,
+  gbifTaxonId, count) and comparing as sets (sidesteps the taxonId-ordering
+  non-determinism noted above).
 - `src/dataframes/geocode_neighbors.py` — TODO: `grid_ring(k=1)` via `h3o`; connectivity
   fixup (single connected component) via `petgraph`. moderate
 - `src/matrices/geocode_connectivity.py` — TODO: build sparse adjacency from neighbor lists

--- a/bioregion_rs/README.md
+++ b/bioregion_rs/README.md
@@ -10,8 +10,10 @@ every subsequent file migration will use.
 - `src/lib.rs` — a PyO3 extension module (`bioregion_rs`) exposing:
   - `darken_hex_color(hex, factor=0.5)` — pure function (plain PyO3 boundary),
     mirrors `src/colors.py`.
-  - `select_geocode(df, precision)` — `pl.DataFrame` → `pl.DataFrame` via `h3o`
-    (pyo3-polars Arrow-FFI boundary), mirrors `src/geocode.py::select_geocode_lf`.
+  - `select_geocode`/`with_geocode`/`filter_by_bounding_box` — mirrors `src/geocode.py`.
+  - `build_geocode` — mirrors `src/dataframes/geocode.py`.
+  - `build_taxonomy` — mirrors `src/dataframes/taxonomy.py`.
+  - `build_geocode_taxa_counts` — mirrors `src/dataframes/geocode_taxa_counts.py`.
 - `harness.py` — runs each Rust function and its Python counterpart on the same
   input and asserts they match. The template for migrating each file.
 

--- a/bioregion_rs/harness.py
+++ b/bioregion_rs/harness.py
@@ -22,6 +22,8 @@ import bioregion_rs
 from src.colors import darken_hex_color as py_darken
 from src.dataframes.darwin_core import build_darwin_core_lf
 from src.dataframes.geocode import build_geocode_df
+from src.dataframes.geocode_taxa_counts import build_geocode_taxa_counts_lf
+from src.dataframes.taxonomy import build_taxonomy_lf
 from src.geocode import (
     filter_by_bounding_box as py_filter_bbox,
     select_geocode_lf,
@@ -141,6 +143,97 @@ def test_build_geocode() -> None:
     )
 
 
+# --- src/dataframes/taxonomy.py, src/dataframes/geocode_taxa_counts.py -------
+
+
+def _load_bbox_darwin_and_geocode_no_edges():
+    """Shared fixture: sample-archive Darwin Core data + its non-edge geocodes."""
+    load_bbox = Bbox.from_coordinates(-90.0, 90.0, -180.0, 180.0)
+    bbox = Bbox.from_coordinates(35.0, 43.5, -50.0, 10.0)
+    precision = 4
+    darwin_lf = build_darwin_core_lf(str(REPO_ROOT / "test" / "sample-archive"), load_bbox)
+    darwin_df = darwin_lf.collect()
+    geocode_df = build_geocode_df(darwin_lf, precision, bbox)
+    geocode_no_edges_df = geocode_df.filter(~pl.col("is_edge"))
+    return bbox, precision, darwin_lf, darwin_df, geocode_no_edges_df
+
+
+def _taxonomy_pairs(taxonomy_df: pl.DataFrame) -> set:
+    return set(taxonomy_df.select("scientificName", "gbifTaxonId").iter_rows())
+
+
+def test_build_taxonomy() -> None:
+    print("src/dataframes/taxonomy.py  (build_taxonomy):")
+    bbox, precision, _darwin_lf, darwin_df, geocode_no_edges_df = (
+        _load_bbox_darwin_and_geocode_no_edges()
+    )
+
+    rust_out = bioregion_rs.build_taxonomy(
+        darwin_df, precision, geocode_no_edges_df,
+        bbox.min_lat, bbox.max_lat, bbox.min_lng, bbox.max_lng,
+    )
+    py_out = build_taxonomy_lf(
+        darwin_df.lazy(), precision, geocode_no_edges_df.lazy(), bbox
+    ).collect()
+
+    check(f"non-trivial: {py_out.height} taxa built", py_out.height > 0)
+    check(
+        "same (scientificName, gbifTaxonId) pair set",
+        _taxonomy_pairs(rust_out) == _taxonomy_pairs(py_out),
+    )
+    check(
+        "taxonId is a 0..n bijection (rust)",
+        set(rust_out["taxonId"].to_list()) == set(range(rust_out.height)),
+    )
+    check(
+        "taxonId is a 0..n bijection (python)",
+        set(py_out["taxonId"].to_list()) == set(range(py_out.height)),
+    )
+
+
+def test_build_geocode_taxa_counts() -> None:
+    print("src/dataframes/geocode_taxa_counts.py  (build_geocode_taxa_counts):")
+    bbox, precision, _darwin_lf, darwin_df, geocode_no_edges_df = (
+        _load_bbox_darwin_and_geocode_no_edges()
+    )
+
+    rust_taxonomy = bioregion_rs.build_taxonomy(
+        darwin_df, precision, geocode_no_edges_df,
+        bbox.min_lat, bbox.max_lat, bbox.min_lng, bbox.max_lng,
+    )
+    py_taxonomy = build_taxonomy_lf(
+        darwin_df.lazy(), precision, geocode_no_edges_df.lazy(), bbox
+    ).collect()
+
+    rust_counts = bioregion_rs.build_geocode_taxa_counts(
+        darwin_df, precision, rust_taxonomy, geocode_no_edges_df,
+        bbox.min_lat, bbox.max_lat, bbox.min_lng, bbox.max_lng,
+    )
+    py_counts = build_geocode_taxa_counts_lf(
+        darwin_df.lazy(), precision, py_taxonomy.lazy(), geocode_no_edges_df.lazy(), bbox
+    ).collect()
+
+    check(f"non-trivial: {py_counts.height} (geocode, taxon) rows built", py_counts.height > 0)
+    check(
+        "total count matches",
+        int(rust_counts["count"].sum()) == int(py_counts["count"].sum()),
+    )
+
+    # taxonId assignment order can differ between engines (unique() ordering is
+    # not guaranteed), so compare by joining back through each engine's own
+    # taxonomy to (geocode, scientificName, gbifTaxonId, count).
+    def _resolved(counts: pl.DataFrame, taxonomy: pl.DataFrame) -> set:
+        joined = counts.join(taxonomy, on="taxonId", how="left")
+        return set(
+            joined.select("geocode", "scientificName", "gbifTaxonId", "count").iter_rows()
+        )
+
+    check(
+        "same (geocode, scientificName, gbifTaxonId, count) set",
+        _resolved(rust_counts, rust_taxonomy) == _resolved(py_counts, py_taxonomy),
+    )
+
+
 # --- parquet stage boundary --------------------------------------------------
 
 
@@ -163,6 +256,8 @@ def main() -> None:
     test_with_geocode()
     test_filter_by_bounding_box()
     test_build_geocode()
+    test_build_taxonomy()
+    test_build_geocode_taxa_counts()
     test_parquet_boundary()
     print("\nAll interop + correctness checks passed.")
 

--- a/bioregion_rs/src/dataframes/geocode.rs
+++ b/bioregion_rs/src/dataframes/geocode.rs
@@ -80,8 +80,8 @@ pub fn build_geocode(
     let geocode_col = UInt64Chunked::from_vec("geocode".into(), cells).into_column();
     let center_col = binary_column("center", &centers);
     let boundary_col = binary_column("boundary", &boundaries);
-    let is_edge_col = BooleanChunked::from_iter_values("is_edge".into(), is_edge.into_iter())
-        .into_column();
+    let is_edge_col =
+        BooleanChunked::from_iter_values("is_edge".into(), is_edge.into_iter()).into_column();
 
     let height = geocode_col.len();
     let out = DataFrame::new(

--- a/bioregion_rs/src/dataframes/geocode_taxa_counts.rs
+++ b/bioregion_rs/src/dataframes/geocode_taxa_counts.rs
@@ -1,0 +1,187 @@
+//! Port of `src/dataframes/geocode_taxa_counts.py` (`build_geocode_taxa_counts_lf`).
+
+use std::collections::HashMap;
+
+use polars::prelude::*;
+use pyo3::prelude::*;
+use pyo3_polars::PyDataFrame;
+
+use crate::dataframes::taxonomy::known_geocodes;
+use crate::geocode::{filter_by_bounding_box_df, with_geocode_df};
+use crate::to_py;
+
+/// Map (scientificName, gbifTaxonId) -> taxonId from a TaxonomySchema DataFrame.
+fn taxon_id_lookup(taxonomy_df: &DataFrame) -> PolarsResult<HashMap<(Option<String>, u32), u32>> {
+    let scientific_name = taxonomy_df
+        .column("scientificName")?
+        .as_materialized_series()
+        .str()?
+        .clone();
+    let gbif_taxon_id = taxonomy_df
+        .column("gbifTaxonId")?
+        .as_materialized_series()
+        .u32()?
+        .clone();
+    let taxon_id = taxonomy_df
+        .column("taxonId")?
+        .as_materialized_series()
+        .u32()?
+        .clone();
+
+    Ok(scientific_name
+        .iter()
+        .zip(gbif_taxon_id.iter())
+        .zip(taxon_id.iter())
+        .filter_map(|((name, gbif_id), tid)| {
+            let gbif_id = gbif_id?;
+            let tid = tid?;
+            Some(((name.map(str::to_string), gbif_id), tid))
+        })
+        .collect())
+}
+
+/// Build a GeocodeTaxaCountsSchema DataFrame from Darwin Core occurrence data.
+///
+/// Mirrors `src/dataframes/geocode_taxa_counts.py::build_geocode_taxa_counts_lf`:
+/// joins occurrences (filtered to known geocodes) against the taxonomy table to
+/// resolve `taxonId`, then aggregates occurrence counts per (geocode, taxonId),
+/// treating a null `individualCount` as 1.
+#[pyfunction]
+#[pyo3(signature = (darwin_core_df, geocode_precision, taxonomy_df, geocode_df, min_lat, max_lat, min_lng, max_lng))]
+#[allow(clippy::too_many_arguments)]
+pub fn build_geocode_taxa_counts(
+    darwin_core_df: PyDataFrame,
+    geocode_precision: u8,
+    taxonomy_df: PyDataFrame,
+    geocode_df: PyDataFrame,
+    min_lat: f64,
+    max_lat: f64,
+    min_lng: f64,
+    max_lng: f64,
+) -> PyResult<PyDataFrame> {
+    let darwin_core_df: DataFrame = darwin_core_df.into();
+    let taxonomy_df: DataFrame = taxonomy_df.into();
+    let geocode_df: DataFrame = geocode_df.into();
+
+    let mut df = darwin_core_df
+        .select([
+            "decimalLatitude",
+            "decimalLongitude",
+            "scientificName",
+            "taxonKey",
+            "individualCount",
+        ])
+        .map_err(to_py)?;
+    df.rename("taxonKey", "gbifTaxonId".into()).map_err(to_py)?;
+
+    let df = filter_by_bounding_box_df(
+        &df,
+        min_lat,
+        max_lat,
+        min_lng,
+        max_lng,
+        "decimalLatitude",
+        "decimalLongitude",
+    )
+    .map_err(to_py)?;
+    let df = with_geocode_df(&df, geocode_precision).map_err(to_py)?;
+
+    let known = known_geocodes(&geocode_df).map_err(to_py)?;
+    let geocode_col = df
+        .column("geocode")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .u64()
+        .map_err(to_py)?;
+    let mask: BooleanChunked = geocode_col
+        .iter()
+        .map(|g| g.is_some_and(|g| known.contains(&g)))
+        .collect();
+    let df = df.filter(&mask).map_err(to_py)?;
+
+    let lookup = taxon_id_lookup(&taxonomy_df).map_err(to_py)?;
+
+    let geocode_ca = df
+        .column("geocode")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .u64()
+        .map_err(to_py)?
+        .clone();
+    let name_ca = df
+        .column("scientificName")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .str()
+        .map_err(to_py)?
+        .clone();
+    let gbif_ca = df
+        .column("gbifTaxonId")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .u32()
+        .map_err(to_py)?
+        .clone();
+    let count_ca = df
+        .column("individualCount")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .i32()
+        .map_err(to_py)?
+        .clone();
+
+    // Inner join against the taxonomy lookup, then fill a null individualCount
+    // with 1 (mirrors `.fill_null(1)` before the sum aggregation).
+    let mut geocodes: Vec<u64> = Vec::new();
+    let mut taxon_ids: Vec<u32> = Vec::new();
+    let mut counts: Vec<u32> = Vec::new();
+    for (((geocode, name), gbif_id), count) in geocode_ca
+        .iter()
+        .zip(name_ca.iter())
+        .zip(gbif_ca.iter())
+        .zip(count_ca.iter())
+    {
+        let (Some(geocode), Some(gbif_id)) = (geocode, gbif_id) else {
+            continue;
+        };
+        let key = (name.map(str::to_string), gbif_id);
+        if let Some(&taxon_id) = lookup.get(&key) {
+            geocodes.push(geocode);
+            taxon_ids.push(taxon_id);
+            counts.push(count.map(|c| c as u32).unwrap_or(1));
+        }
+    }
+
+    let joined = DataFrame::new(
+        geocodes.len(),
+        vec![
+            UInt64Chunked::from_vec("geocode".into(), geocodes).into_column(),
+            UInt32Chunked::from_vec("taxonId".into(), taxon_ids).into_column(),
+            UInt32Chunked::from_vec("individualCount".into(), counts).into_column(),
+        ],
+    )
+    .map_err(to_py)?;
+
+    // `GroupBy::sum` is deprecated in favor of lazy `.agg()` expressions, which
+    // aren't available here (the `lazy` feature doesn't compile on this
+    // toolchain — see the crate README). This eager aggregation is correct and
+    // is the only group-by-sum path available without it.
+    #[allow(deprecated)]
+    let grouped = joined
+        .group_by(["geocode", "taxonId"])
+        .map_err(to_py)?
+        .select(["individualCount"])
+        .sum()
+        .map_err(to_py)?;
+
+    let mut grouped = grouped;
+    grouped
+        .rename("individualCount_sum", "count".into())
+        .map_err(to_py)?;
+
+    let out = grouped
+        .sort(["geocode"], SortMultipleOptions::default())
+        .map_err(to_py)?;
+
+    Ok(PyDataFrame(out))
+}

--- a/bioregion_rs/src/dataframes/mod.rs
+++ b/bioregion_rs/src/dataframes/mod.rs
@@ -1,3 +1,5 @@
 //! Ports of `src/dataframes/*.py`.
 
 pub mod geocode;
+pub mod geocode_taxa_counts;
+pub mod taxonomy;

--- a/bioregion_rs/src/dataframes/taxonomy.rs
+++ b/bioregion_rs/src/dataframes/taxonomy.rs
@@ -1,0 +1,90 @@
+//! Port of `src/dataframes/taxonomy.py`.
+
+use std::collections::HashSet;
+
+use polars::prelude::*;
+use pyo3::prelude::*;
+use pyo3_polars::PyDataFrame;
+
+use crate::geocode::{filter_by_bounding_box_df, with_geocode_df};
+use crate::to_py;
+
+/// Set of known geocodes as a plain u64 hash set, for semi-join-style filtering.
+pub(crate) fn known_geocodes(geocode_df: &DataFrame) -> PolarsResult<HashSet<u64>> {
+    Ok(geocode_df
+        .column("geocode")?
+        .as_materialized_series()
+        .u64()?
+        .into_no_null_iter()
+        .collect())
+}
+
+/// Build a mask selecting rows of `df` whose `geocode` column is in `known`.
+fn known_geocode_mask(df: &DataFrame, known: &HashSet<u64>) -> PolarsResult<BooleanChunked> {
+    let geocode = df.column("geocode")?.as_materialized_series().u64()?;
+    Ok(geocode
+        .iter()
+        .map(|g| g.is_some_and(|g| known.contains(&g)))
+        .collect())
+}
+
+/// Build a TaxonomySchema DataFrame from Darwin Core occurrence data.
+///
+/// Mirrors `src/dataframes/taxonomy.py::build_taxonomy_lf`: distinct
+/// (scientificName, gbifTaxonId) pairs among occurrences that fall within a
+/// known (non-edge) geocode, each assigned a synthetic `taxonId`.
+///
+/// Note: row order (and therefore the `taxonId` assigned to each pair) is not
+/// guaranteed to match the Python implementation's `.unique()` ordering — only
+/// the set of pairs and the bijection with `taxonId` are guaranteed.
+#[pyfunction]
+#[pyo3(signature = (darwin_core_df, geocode_precision, geocode_df, min_lat, max_lat, min_lng, max_lng))]
+#[allow(clippy::too_many_arguments)]
+pub fn build_taxonomy(
+    darwin_core_df: PyDataFrame,
+    geocode_precision: u8,
+    geocode_df: PyDataFrame,
+    min_lat: f64,
+    max_lat: f64,
+    min_lng: f64,
+    max_lng: f64,
+) -> PyResult<PyDataFrame> {
+    let darwin_core_df: DataFrame = darwin_core_df.into();
+    let geocode_df: DataFrame = geocode_df.into();
+
+    let mut df = darwin_core_df
+        .select([
+            "decimalLatitude",
+            "decimalLongitude",
+            "scientificName",
+            "taxonKey",
+        ])
+        .map_err(to_py)?;
+    df.rename("taxonKey", "gbifTaxonId".into()).map_err(to_py)?;
+
+    let df = filter_by_bounding_box_df(
+        &df,
+        min_lat,
+        max_lat,
+        min_lng,
+        max_lng,
+        "decimalLatitude",
+        "decimalLongitude",
+    )
+    .map_err(to_py)?;
+    let df = with_geocode_df(&df, geocode_precision).map_err(to_py)?;
+
+    let known = known_geocodes(&geocode_df).map_err(to_py)?;
+    let mask = known_geocode_mask(&df, &known).map_err(to_py)?;
+    let df = df.filter(&mask).map_err(to_py)?;
+
+    let df = df
+        .select(["scientificName", "gbifTaxonId"])
+        .map_err(to_py)?;
+    let df = df
+        .unique::<&str, String>(None, UniqueKeepStrategy::Any, None)
+        .map_err(to_py)?;
+    let df = df.with_row_index("taxonId".into(), None).map_err(to_py)?;
+
+    Ok(PyDataFrame(df))
+}

--- a/bioregion_rs/src/geocode.rs
+++ b/bioregion_rs/src/geocode.rs
@@ -27,7 +27,9 @@ pub(crate) fn latlng_to_geocode(
         .iter()
         .zip(lng.iter())
         .map(|(la, lo)| match (la, lo) {
-            (Some(la), Some(lo)) => LatLng::new(la, lo).ok().map(|ll| u64::from(ll.to_cell(res))),
+            (Some(la), Some(lo)) => LatLng::new(la, lo)
+                .ok()
+                .map(|ll| u64::from(ll.to_cell(res))),
             _ => None,
         })
         .collect();
@@ -73,6 +75,46 @@ pub fn with_geocode(df: PyDataFrame, precision: u8) -> PyResult<PyDataFrame> {
     Ok(PyDataFrame(df))
 }
 
+/// Filter a DataFrame to rows whose lat/lng (by column name) are non-null and
+/// within the bounding box (inclusive on both bounds).
+///
+/// Mirrors `src/geocode.py::filter_by_bounding_box`.
+pub(crate) fn filter_by_bounding_box_df(
+    df: &DataFrame,
+    min_lat: f64,
+    max_lat: f64,
+    min_lng: f64,
+    max_lng: f64,
+    lat_col: &str,
+    lng_col: &str,
+) -> PolarsResult<DataFrame> {
+    let (lat, lng) = latlng_columns(df, lat_col, lng_col)?;
+    let lat = lat.f64()?;
+    let lng = lng.f64()?;
+    let mask: BooleanChunked = lat
+        .iter()
+        .zip(lng.iter())
+        .map(|(la, lo)| match (la, lo) {
+            (Some(la), Some(lo)) => {
+                la >= min_lat && la <= max_lat && lo >= min_lng && lo <= max_lng
+            }
+            _ => false,
+        })
+        .collect();
+    df.filter(&mask)
+}
+
+/// Return the input DataFrame with an added `geocode` (UInt64) column, reading
+/// lat/lng from `decimalLatitude` / `decimalLongitude`.
+pub(crate) fn with_geocode_df(df: &DataFrame, precision: u8) -> PolarsResult<DataFrame> {
+    let mut df = df.clone();
+    let res = resolution_from_u8(precision)?;
+    let (lat, lng) = latlng_columns(&df, "decimalLatitude", "decimalLongitude")?;
+    let geocode = latlng_to_geocode(lat, lng, res)?;
+    df.with_column(geocode.into_column())?;
+    Ok(df)
+}
+
 /// Filter a DataFrame to rows whose lat/lng are non-null and within the bounding
 /// box (inclusive on both bounds).
 ///
@@ -94,20 +136,9 @@ pub fn filter_by_bounding_box(
     lng_col: String,
 ) -> PyResult<PyDataFrame> {
     let df: DataFrame = df.into();
-    let (lat, lng) = latlng_columns(&df, &lat_col, &lng_col).map_err(to_py)?;
-    let lat = lat.f64().map_err(to_py)?;
-    let lng = lng.f64().map_err(to_py)?;
-    let mask: BooleanChunked = lat
-        .iter()
-        .zip(lng.iter())
-        .map(|(la, lo)| match (la, lo) {
-            (Some(la), Some(lo)) => {
-                la >= min_lat && la <= max_lat && lo >= min_lng && lo <= max_lng
-            }
-            _ => false,
-        })
-        .collect();
-    let out = df.filter(&mask).map_err(to_py)?;
+    let out =
+        filter_by_bounding_box_df(&df, min_lat, max_lat, min_lng, max_lng, &lat_col, &lng_col)
+            .map_err(to_py)?;
     Ok(PyDataFrame(out))
 }
 

--- a/bioregion_rs/src/lib.rs
+++ b/bioregion_rs/src/lib.rs
@@ -27,5 +27,10 @@ fn bioregion_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(geocode::with_geocode, m)?)?;
     m.add_function(wrap_pyfunction!(geocode::filter_by_bounding_box, m)?)?;
     m.add_function(wrap_pyfunction!(dataframes::geocode::build_geocode, m)?)?;
+    m.add_function(wrap_pyfunction!(dataframes::taxonomy::build_taxonomy, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        dataframes::geocode_taxa_counts::build_geocode_taxa_counts,
+        m
+    )?)?;
     Ok(())
 }

--- a/bioregion_rs/src/wkb.rs
+++ b/bioregion_rs/src/wkb.rs
@@ -51,7 +51,10 @@ mod tests {
         let ring = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 0.0)];
         let b = polygon(&ring);
         assert_eq!(b[0], BYTE_ORDER_LE);
-        assert_eq!(u32::from_le_bytes(b[1..5].try_into().unwrap()), TYPE_POLYGON);
+        assert_eq!(
+            u32::from_le_bytes(b[1..5].try_into().unwrap()),
+            TYPE_POLYGON
+        );
         assert_eq!(u32::from_le_bytes(b[5..9].try_into().unwrap()), 1);
         assert_eq!(u32::from_le_bytes(b[9..13].try_into().unwrap()), 4);
     }


### PR DESCRIPTION
## Summary
- Ports `src/dataframes/taxonomy.py::build_taxonomy_lf` and `src/dataframes/geocode_taxa_counts.py::build_geocode_taxa_counts_lf` to Rust (`build_taxonomy`, `build_geocode_taxa_counts` in `bioregion_rs`).
- Both use the eager `polars-core` API only (`group_by`/`unique`/`with_row_index`) — the `lazy` feature set still doesn't compile on this toolchain (per Phase 0 findings), and semi-joins / the taxonomy join are hand-rolled via `HashSet`/`HashMap` lookups rather than pulling in `polars-ops`.
- `filter_top_taxa_lf` (an optional scaling filter, not on the critical path) is deferred.
- Extends `bioregion_rs/harness.py` to diff both new functions against their Python counterparts on the sample archive; all checks pass, plus existing `cargo test --lib` unit tests and `pyright`.

## Test plan
- [x] `cargo test --lib` (5 tests pass)
- [x] `uv run maturin develop --manifest-path bioregion_rs/Cargo.toml`
- [x] `uv run python bioregion_rs/harness.py` (all checks pass, including new `build_taxonomy`/`build_geocode_taxa_counts` checks)
- [x] `uv run pyright` (0 errors)

https://claude.ai/code/session_01XefuZ41iibHEgQrxWiqDjg