### PR TITLE
Phase 1: port geocode_neighbors.py to Rust

### DIFF
--- a/RUST_MIGRATION_PLAN.md
+++ b/RUST_MIGRATION_PLAN.md
@@ -217,8 +217,18 @@ verified against Python in `bioregion_rs/harness.py`.
   engines' output back through their own taxonomy to (geocode, scientificName,
   gbifTaxonId, count) and comparing as sets (sidesteps the taxonId-ordering
   non-determinism noted above).
-- `src/dataframes/geocode_neighbors.py` — TODO: `grid_ring(k=1)` via `h3o`; connectivity
-  fixup (single connected component) via `petgraph`. moderate
+- `src/dataframes/geocode_neighbors.py` — ✅ DONE: `build_geocode_neighbors` and
+  `build_geocode_neighbors_no_edges` (H3 `grid_ring_fast(1)` for direct adjacency; a
+  hand-rolled union-find + brute-force nearest-point search for the connectivity fixup,
+  instead of `petgraph` — the graph is tiny per bioregion and this avoids a new
+  dependency). The public `graph()` helper (produces an `nx.Graph` for downstream
+  consumers) stays in Python unchanged — it's a thin, Python-object-specific wrapper
+  around whichever engine produced the `GeocodeNeighborsSchema` DataFrame. Verified
+  against Python by comparing `direct_neighbors`/`direct_and_indirect_neighbors` as
+  per-geocode sets (order-independent) and confirming both outputs are a single
+  connected component; the indirect-edge tie-break (nearest pair when multiple
+  candidates are equidistant) matched Python exactly on the test fixture, though this
+  isn't guaranteed in general — see the caveat in `geocode_neighbors.rs`.
 - `src/matrices/geocode_connectivity.py` — TODO: build sparse adjacency from neighbor lists
   (CSR via `sprs` or dense `ndarray`).
 

--- a/bioregion_rs/README.md
+++ b/bioregion_rs/README.md
@@ -14,6 +14,8 @@ every subsequent file migration will use.
   - `build_geocode` — mirrors `src/dataframes/geocode.py`.
   - `build_taxonomy` — mirrors `src/dataframes/taxonomy.py`.
   - `build_geocode_taxa_counts` — mirrors `src/dataframes/geocode_taxa_counts.py`.
+  - `build_geocode_neighbors`/`build_geocode_neighbors_no_edges` — mirrors
+    `src/dataframes/geocode_neighbors.py`.
 - `harness.py` — runs each Rust function and its Python counterpart on the same
   input and asserts they match. The template for migrating each file.
 

--- a/bioregion_rs/harness.py
+++ b/bioregion_rs/harness.py
@@ -22,6 +22,11 @@ import bioregion_rs
 from src.colors import darken_hex_color as py_darken
 from src.dataframes.darwin_core import build_darwin_core_lf
 from src.dataframes.geocode import build_geocode_df
+from src.dataframes.geocode_neighbors import (
+    build_geocode_neighbors_df,
+    build_geocode_neighbors_no_edges_df,
+    graph as neighbors_graph,
+)
 from src.dataframes.geocode_taxa_counts import build_geocode_taxa_counts_lf
 from src.dataframes.taxonomy import build_taxonomy_lf
 from src.geocode import (
@@ -234,6 +239,74 @@ def test_build_geocode_taxa_counts() -> None:
     )
 
 
+# --- src/dataframes/geocode_neighbors.py --------------------------------------
+
+
+def _neighbor_sets(df: pl.DataFrame, column: str) -> dict:
+    return {geocode: set(neighbors) for geocode, neighbors in df.select("geocode", column).iter_rows()}
+
+
+def _is_single_component(df: pl.DataFrame, include_indirect_neighbors: bool) -> bool:
+    import networkx as nx
+
+    g = neighbors_graph(df, include_indirect_neighbors=include_indirect_neighbors)
+    return nx.number_connected_components(g) == 1
+
+
+def test_build_geocode_neighbors() -> None:
+    print("src/dataframes/geocode_neighbors.py  (build_geocode_neighbors):")
+    bbox, precision, _darwin_lf, darwin_df, _geocode_no_edges_df = (
+        _load_bbox_darwin_and_geocode_no_edges()
+    )
+    geocode_df = build_geocode_df(darwin_df.lazy(), precision, bbox)
+
+    rust_out = bioregion_rs.build_geocode_neighbors(geocode_df)
+    py_out = build_geocode_neighbors_df(geocode_df)
+
+    check(f"non-trivial: {py_out.height} geocodes", py_out.height > 1)
+    check("same geocode order", rust_out["geocode"].equals(py_out["geocode"]))
+    check(
+        "same direct_neighbors set per geocode",
+        _neighbor_sets(rust_out, "direct_neighbors") == _neighbor_sets(py_out, "direct_neighbors"),
+    )
+    check("rust output is a single connected component", _is_single_component(rust_out, True))
+    check("python output is a single connected component", _is_single_component(py_out, True))
+    check(
+        "same direct_and_indirect_neighbors set per geocode",
+        _neighbor_sets(rust_out, "direct_and_indirect_neighbors")
+        == _neighbor_sets(py_out, "direct_and_indirect_neighbors"),
+    )
+
+
+def test_build_geocode_neighbors_no_edges() -> None:
+    print("src/dataframes/geocode_neighbors.py  (build_geocode_neighbors_no_edges):")
+    bbox, precision, _darwin_lf, darwin_df, geocode_no_edges_df = (
+        _load_bbox_darwin_and_geocode_no_edges()
+    )
+    geocode_df = build_geocode_df(darwin_df.lazy(), precision, bbox)
+
+    rust_neighbors = bioregion_rs.build_geocode_neighbors(geocode_df)
+    py_neighbors = build_geocode_neighbors_df(geocode_df)
+
+    rust_out = bioregion_rs.build_geocode_neighbors_no_edges(rust_neighbors, geocode_no_edges_df)
+    py_out = build_geocode_neighbors_no_edges_df(py_neighbors, geocode_no_edges_df)
+
+    check(f"non-trivial: {py_out.height} geocodes", 0 < py_out.height < geocode_df.height)
+    check("sorted by geocode (rust)", rust_out["geocode"].is_sorted())
+    check("same geocode set", set(rust_out["geocode"].to_list()) == set(py_out["geocode"].to_list()))
+    check(
+        "same direct_neighbors set per geocode",
+        _neighbor_sets(rust_out, "direct_neighbors") == _neighbor_sets(py_out, "direct_neighbors"),
+    )
+    check("rust output is a single connected component", _is_single_component(rust_out, True))
+    check("python output is a single connected component", _is_single_component(py_out, True))
+    check(
+        "same direct_and_indirect_neighbors set per geocode",
+        _neighbor_sets(rust_out, "direct_and_indirect_neighbors")
+        == _neighbor_sets(py_out, "direct_and_indirect_neighbors"),
+    )
+
+
 # --- parquet stage boundary --------------------------------------------------
 
 
@@ -258,6 +331,8 @@ def main() -> None:
     test_build_geocode()
     test_build_taxonomy()
     test_build_geocode_taxa_counts()
+    test_build_geocode_neighbors()
+    test_build_geocode_neighbors_no_edges()
     test_parquet_boundary()
     print("\nAll interop + correctness checks passed.")
 

--- a/bioregion_rs/src/dataframes/geocode_neighbors.rs
+++ b/bioregion_rs/src/dataframes/geocode_neighbors.rs
@@ -1,0 +1,300 @@
+//! Port of `src/dataframes/geocode_neighbors.py`.
+
+use std::collections::{HashMap, HashSet};
+
+use h3o::CellIndex;
+use polars::prelude::*;
+use pyo3::prelude::*;
+use pyo3_polars::PyDataFrame;
+
+use crate::dataframes::taxonomy::known_geocodes;
+use crate::{to_py, wkb};
+
+const MAX_NUM_NEIGHBORS: usize = 6;
+
+/// Working state for one geocode row while building/reducing the neighbor graph.
+struct Node {
+    geocode: u64,
+    center: (f64, f64),
+    direct_neighbors: Vec<u64>,
+    direct_and_indirect_neighbors: Vec<u64>,
+}
+
+/// Minimal union-find over row indices, used to track connected components
+/// without pulling in a graph crate.
+struct UnionFind {
+    parent: Vec<usize>,
+}
+
+impl UnionFind {
+    fn new(n: usize) -> Self {
+        Self {
+            parent: (0..n).collect(),
+        }
+    }
+
+    fn find(&mut self, i: usize) -> usize {
+        if self.parent[i] != i {
+            self.parent[i] = self.find(self.parent[i]);
+        }
+        self.parent[i]
+    }
+
+    fn union(&mut self, a: usize, b: usize) {
+        let (ra, rb) = (self.find(a), self.find(b));
+        if ra != rb {
+            self.parent[ra] = rb;
+        }
+    }
+
+    fn num_components(&mut self) -> usize {
+        let n = self.parent.len();
+        let roots: HashSet<usize> = (0..n).map(|i| self.find(i)).collect();
+        roots.len()
+    }
+}
+
+/// Repeatedly connect the first (by row order) connected component to the
+/// spatially nearest node in another component (skipping nodes that already
+/// have `MAX_NUM_NEIGHBORS` direct neighbors), until a single component
+/// remains. Mirrors `_reduce_connected_components_to_one`.
+///
+/// Distance ties (equidistant candidate pairs) are broken by row order here,
+/// which is not guaranteed to match shapely/GEOS's internal tie-break in the
+/// Python implementation; in practice centers are real-valued coordinates so
+/// exact ties don't occur.
+fn reduce_connected_components_to_one(nodes: &mut [Node]) -> PolarsResult<()> {
+    let n = nodes.len();
+    if n == 0 {
+        return Ok(());
+    }
+    let index_of: HashMap<u64, usize> = nodes
+        .iter()
+        .enumerate()
+        .map(|(i, node)| (node.geocode, i))
+        .collect();
+
+    let mut uf = UnionFind::new(n);
+    for (i, node) in nodes.iter().enumerate() {
+        for &neighbor in &node.direct_neighbors {
+            if let Some(&j) = index_of.get(&neighbor) {
+                uf.union(i, j);
+            }
+        }
+    }
+
+    while uf.num_components() > 1 {
+        let first_root = uf.find(0);
+
+        let mut best: Option<(usize, usize, f64)> = None;
+        for i in 0..n {
+            if uf.find(i) != first_root {
+                continue;
+            }
+            for (j, other) in nodes.iter().enumerate() {
+                if uf.find(j) == first_root || other.direct_neighbors.len() == MAX_NUM_NEIGHBORS {
+                    continue;
+                }
+                let (xi, yi) = nodes[i].center;
+                let (xj, yj) = other.center;
+                let dist_sq = (xi - xj).powi(2) + (yi - yj).powi(2);
+                if best.is_none_or(|(_, _, best_dist)| dist_sq < best_dist) {
+                    best = Some((i, j, dist_sq));
+                }
+            }
+        }
+
+        let (i, j, _) = best.ok_or_else(|| {
+            PolarsError::ComputeError(
+                "No closest pair found while connecting geocode neighbor components".into(),
+            )
+        })?;
+
+        uf.union(i, j);
+        let (geocode_i, geocode_j) = (nodes[i].geocode, nodes[j].geocode);
+        nodes[i].direct_and_indirect_neighbors.push(geocode_j);
+        nodes[j].direct_and_indirect_neighbors.push(geocode_i);
+    }
+
+    Ok(())
+}
+
+/// Decode the `geocode` (UInt64) and `center` (WKB Point Binary) columns of a
+/// DataFrame into row-aligned vectors.
+fn geocode_and_centers(df: &DataFrame) -> PolarsResult<(Vec<u64>, Vec<(f64, f64)>)> {
+    let geocodes: Vec<u64> = df
+        .column("geocode")?
+        .as_materialized_series()
+        .u64()?
+        .into_no_null_iter()
+        .collect();
+    let centers: Vec<(f64, f64)> = df
+        .column("center")?
+        .as_materialized_series()
+        .binary()?
+        .iter()
+        .map(|b| wkb::decode_point(b.expect("center column must be non-null")))
+        .collect();
+    Ok((geocodes, centers))
+}
+
+/// Build a DataFrame's `geocode` (UInt64) + two List<UInt64> neighbor columns.
+fn neighbors_to_df(nodes: &[Node]) -> PolarsResult<DataFrame> {
+    let geocode_col =
+        UInt64Chunked::from_vec("geocode".into(), nodes.iter().map(|n| n.geocode).collect())
+            .into_column();
+
+    let mut direct_builder = ListPrimitiveChunkedBuilder::<UInt64Type>::new(
+        "direct_neighbors".into(),
+        nodes.len(),
+        nodes.len() * MAX_NUM_NEIGHBORS,
+        DataType::UInt64,
+    );
+    let mut direct_and_indirect_builder = ListPrimitiveChunkedBuilder::<UInt64Type>::new(
+        "direct_and_indirect_neighbors".into(),
+        nodes.len(),
+        nodes.len() * MAX_NUM_NEIGHBORS,
+        DataType::UInt64,
+    );
+    for node in nodes {
+        direct_builder.append_slice(&node.direct_neighbors);
+        direct_and_indirect_builder.append_slice(&node.direct_and_indirect_neighbors);
+    }
+
+    DataFrame::new(
+        nodes.len(),
+        vec![
+            geocode_col,
+            direct_builder.finish().into_series().into_column(),
+            direct_and_indirect_builder
+                .finish()
+                .into_series()
+                .into_column(),
+        ],
+    )
+}
+
+/// Build a GeocodeNeighborsSchema DataFrame from geocode spatial data.
+///
+/// Mirrors `src/dataframes/geocode_neighbors.py::build_geocode_neighbors_df`:
+/// H3 grid-ring adjacency restricted to this DataFrame's own geocode set, then
+/// indirect edges added (nearest-point heuristic) until the neighbor graph is
+/// a single connected component.
+#[pyfunction]
+pub fn build_geocode_neighbors(geocode_df: PyDataFrame) -> PyResult<PyDataFrame> {
+    let geocode_df: DataFrame = geocode_df.into();
+
+    let (geocodes, centers) = geocode_and_centers(&geocode_df).map_err(to_py)?;
+    let known: HashSet<u64> = geocodes.iter().copied().collect();
+
+    let mut nodes: Vec<Node> = Vec::with_capacity(geocodes.len());
+    for (&geocode, &center) in geocodes.iter().zip(centers.iter()) {
+        let cell = CellIndex::try_from(geocode).map_err(|e| {
+            to_py(PolarsError::ComputeError(
+                format!("invalid H3 cell {geocode}: {e}").into(),
+            ))
+        })?;
+        let direct_neighbors: Vec<u64> = cell
+            .grid_ring_fast(1)
+            .flatten()
+            .map(u64::from)
+            .filter(|c| known.contains(c))
+            .collect();
+        nodes.push(Node {
+            geocode,
+            center,
+            direct_and_indirect_neighbors: direct_neighbors.clone(),
+            direct_neighbors,
+        });
+    }
+
+    reduce_connected_components_to_one(&mut nodes).map_err(to_py)?;
+
+    let out = neighbors_to_df(&nodes).map_err(to_py)?;
+    Ok(PyDataFrame(out))
+}
+
+/// Build a GeocodeNeighborsSchema DataFrame restricted to non-edge geocodes.
+///
+/// Mirrors `build_geocode_neighbors_no_edges_df`: filter neighbor lists down
+/// to the valid (non-edge) geocode set, re-attach centers, and re-run the
+/// connectivity fixup since removing edge geocodes can re-fragment the graph.
+#[pyfunction]
+pub fn build_geocode_neighbors_no_edges(
+    geocode_neighbors_df: PyDataFrame,
+    geocode_no_edges_df: PyDataFrame,
+) -> PyResult<PyDataFrame> {
+    let geocode_neighbors_df: DataFrame = geocode_neighbors_df.into();
+    let geocode_no_edges_df: DataFrame = geocode_no_edges_df.into();
+
+    let valid = known_geocodes(&geocode_no_edges_df).map_err(to_py)?;
+    let (no_edges_geocodes, no_edges_centers) =
+        geocode_and_centers(&geocode_no_edges_df).map_err(to_py)?;
+    let center_by_geocode: HashMap<u64, (f64, f64)> = no_edges_geocodes
+        .into_iter()
+        .zip(no_edges_centers)
+        .collect();
+
+    let geocode_ca = geocode_neighbors_df
+        .column("geocode")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .u64()
+        .map_err(to_py)?
+        .clone();
+    let direct_ca = geocode_neighbors_df
+        .column("direct_neighbors")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .list()
+        .map_err(to_py)?
+        .clone();
+    let direct_and_indirect_ca = geocode_neighbors_df
+        .column("direct_and_indirect_neighbors")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .list()
+        .map_err(to_py)?
+        .clone();
+
+    let mut nodes: Vec<Node> = Vec::new();
+    for i in 0..geocode_neighbors_df.height() {
+        let Some(geocode) = geocode_ca.get(i) else {
+            continue;
+        };
+        if !valid.contains(&geocode) {
+            continue;
+        }
+        let list_as_u64 = |list_ca: &ListChunked| -> PolarsResult<Vec<u64>> {
+            Ok(list_ca
+                .get_as_series(i)
+                .map(|s| {
+                    s.u64()
+                        .expect("neighbor list column must be UInt64")
+                        .into_no_null_iter()
+                        .filter(|c| valid.contains(c))
+                        .collect()
+                })
+                .unwrap_or_default())
+        };
+        let direct_neighbors = list_as_u64(&direct_ca).map_err(to_py)?;
+        let direct_and_indirect_neighbors = list_as_u64(&direct_and_indirect_ca).map_err(to_py)?;
+        let center = *center_by_geocode.get(&geocode).ok_or_else(|| {
+            to_py(PolarsError::ComputeError(
+                format!("geocode {geocode} missing from geocode_no_edges_df").into(),
+            ))
+        })?;
+        nodes.push(Node {
+            geocode,
+            center,
+            direct_neighbors,
+            direct_and_indirect_neighbors,
+        });
+    }
+
+    reduce_connected_components_to_one(&mut nodes).map_err(to_py)?;
+    nodes.sort_by_key(|n| n.geocode);
+
+    let out = neighbors_to_df(&nodes).map_err(to_py)?;
+    Ok(PyDataFrame(out))
+}

--- a/bioregion_rs/src/dataframes/mod.rs
+++ b/bioregion_rs/src/dataframes/mod.rs
@@ -1,5 +1,6 @@
 //! Ports of `src/dataframes/*.py`.
 
 pub mod geocode;
+pub mod geocode_neighbors;
 pub mod geocode_taxa_counts;
 pub mod taxonomy;

--- a/bioregion_rs/src/lib.rs
+++ b/bioregion_rs/src/lib.rs
@@ -32,5 +32,13 @@ fn bioregion_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
         dataframes::geocode_taxa_counts::build_geocode_taxa_counts,
         m
     )?)?;
+    m.add_function(wrap_pyfunction!(
+        dataframes::geocode_neighbors::build_geocode_neighbors,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(
+        dataframes::geocode_neighbors::build_geocode_neighbors_no_edges,
+        m
+    )?)?;
     Ok(())
 }

--- a/bioregion_rs/src/wkb.rs
+++ b/bioregion_rs/src/wkb.rs
@@ -32,6 +32,20 @@ pub fn polygon(ring: &[(f64, f64)]) -> Vec<u8> {
     buf
 }
 
+/// Decode a WKB-encoded 2D point back to (x, y). Panics on malformed input;
+/// only intended for round-tripping this module's own `point()` output.
+pub fn decode_point(bytes: &[u8]) -> (f64, f64) {
+    assert_eq!(
+        bytes[0], BYTE_ORDER_LE,
+        "only little-endian WKB is supported"
+    );
+    let kind = u32::from_le_bytes(bytes[1..5].try_into().unwrap());
+    assert_eq!(kind, TYPE_POINT, "expected a WKB Point");
+    let x = f64::from_le_bytes(bytes[5..13].try_into().unwrap());
+    let y = f64::from_le_bytes(bytes[13..21].try_into().unwrap());
+    (x, y)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -44,6 +58,7 @@ mod tests {
         assert_eq!(u32::from_le_bytes(b[1..5].try_into().unwrap()), TYPE_POINT);
         assert_eq!(f64::from_le_bytes(b[5..13].try_into().unwrap()), 1.0);
         assert_eq!(f64::from_le_bytes(b[13..21].try_into().unwrap()), 2.0);
+        assert_eq!(decode_point(&b), (1.0, 2.0));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Ports `src/dataframes/geocode_neighbors.py`'s `build_geocode_neighbors_df` and `build_geocode_neighbors_no_edges_df` to Rust (`build_geocode_neighbors`, `build_geocode_neighbors_no_edges` in `bioregion_rs`).
- H3 `grid_ring_fast(1)` (via `h3o`) for direct neighbor adjacency, restricted to the input DataFrame's own geocode set.
- The connectivity fixup (adding indirect edges until the neighbor graph is a single connected component) is hand-rolled with a small union-find plus a brute-force nearest-point search over WKB-decoded centers, rather than adding `petgraph` — the per-bioregion neighbor graph is small enough that this isn't a real cost, and it keeps the crate's dependency surface unchanged.
- The `graph()` helper (builds an `nx.Graph` for downstream consumers) stays in Python unchanged — it's a thin, networkx-object-specific wrapper that works fine over a Rust-produced `GeocodeNeighborsSchema` DataFrame since the schema is unchanged.
- Extends `bioregion_rs/harness.py`: compares `direct_neighbors`/`direct_and_indirect_neighbors` as per-geocode sets (order-independent) and confirms both engines' outputs are a single connected component; the indirect-edge tie-break matched Python exactly on the test fixture (noted as a non-guaranteed coincidence in the code, since exact ties in the nearest-point search resolve differently between engines in principle).

## Test plan
- [x] `cargo test --lib` (5 tests pass)
- [x] `uv run maturin develop --manifest-path bioregion_rs/Cargo.toml`
- [x] `uv run python bioregion_rs/harness.py` (all checks pass, including the new `build_geocode_neighbors`/`build_geocode_neighbors_no_edges` checks)
- [x] `uv run pyright` (0 errors)

https://claude.ai/code/session_01XefuZ41iibHEgQrxWiqDjg