### PR TITLE
Phase 1: port geocode_connectivity.py to Rust; add bioregion_rs CI job

### DIFF
--- a/.github/workflows/bioregion-rs.yml
+++ b/.github/workflows/bioregion-rs.yml
@@ -1,0 +1,31 @@
+name: bioregion_rs
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+      - name: Cache cargo registry and build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            bioregion_rs/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('bioregion_rs/Cargo.lock') }}
+      - name: cargo test (Rust unit tests)
+        working-directory: bioregion_rs
+        run: PYO3_PYTHON=$(cd .. && uv run which python) cargo test --lib
+      - name: Build the bioregion_rs extension into the venv
+        run: uv run maturin develop --manifest-path bioregion_rs/Cargo.toml
+      - name: Run interop/correctness harness (Rust output vs Python output)
+        run: uv run python bioregion_rs/harness.py

--- a/.github/workflows/bioregion-rs.yml
+++ b/.github/workflows/bioregion-rs.yml
@@ -24,7 +24,15 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('bioregion_rs/Cargo.lock') }}
       - name: cargo test (Rust unit tests)
         working-directory: bioregion_rs
-        run: PYO3_PYTHON=$(cd .. && uv run which python) cargo test --lib
+        # cargo test's standalone binary links libpython dynamically but
+        # doesn't get an rpath to uv's managed Python, so point the runtime
+        # loader at it explicitly (see the "cargo test + PyO3 note" in
+        # bioregion_rs/README.md).
+        run: |
+          PYTHON_LIBDIR=$(cd .. && uv run python -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))")
+          PYO3_PYTHON=$(cd .. && uv run which python) \
+            LD_LIBRARY_PATH="$PYTHON_LIBDIR:$LD_LIBRARY_PATH" \
+            cargo test --lib
       - name: Build the bioregion_rs extension into the venv
         run: uv run maturin develop --manifest-path bioregion_rs/Cargo.toml
       - name: Run interop/correctness harness (Rust output vs Python output)

--- a/RUST_MIGRATION_PLAN.md
+++ b/RUST_MIGRATION_PLAN.md
@@ -229,8 +229,24 @@ verified against Python in `bioregion_rs/harness.py`.
   connected component; the indirect-edge tie-break (nearest pair when multiple
   candidates are equidistant) matched Python exactly on the test fixture, though this
   isn't guaranteed in general — see the caveat in `geocode_neighbors.rs`.
-- `src/matrices/geocode_connectivity.py` — TODO: build sparse adjacency from neighbor lists
-  (CSR via `sprs` or dense `ndarray`).
+- `src/matrices/geocode_connectivity.py` — ✅ DONE: `build_geocode_connectivity_matrix`
+  builds the dense 0/1 adjacency matrix from `direct_and_indirect_neighbors`, returned
+  as a nested `Vec<Vec<i64>>` (plain Python list of lists — no `ndarray`/`sprs`
+  dependency; PyO3 converts nested `Vec<u8>` to Python `bytes`, which is why cells are
+  `i64` rather than a narrower type) for the Python side to wrap with `np.array(...)`.
+  The single-connected-component invariant is checked via a small BFS (instead of
+  `networkx`) and raises instead of Python's `assert`. Verified against
+  `GeocodeConnectivityMatrix.build`'s output for exact matrix equality.
+
+This closes out Phase 1's non-trivial files. `bioregion_rs` now has CI
+(`.github/workflows/bioregion-rs.yml`): `cargo test --lib`, `maturin develop`, and
+`harness.py` run on every push, so a Rust change that breaks parity with Python fails
+CI instead of relying on someone running the harness locally. Note this is a
+crate-level check only — the main pipeline's own CI (`run.yml`) still runs the
+all-Python `notebook.py` end-to-end and does not yet invoke `bioregion_rs` at all,
+since no pipeline call site has been switched over to Rust yet (see "Recommended end
+state" above — that cutover is a later step, done file-by-file once each port is
+validated).
 
 ### Phase 2 — graph, geometry, and stats (⚠️ ported algorithms)
 

--- a/bioregion_rs/README.md
+++ b/bioregion_rs/README.md
@@ -63,5 +63,19 @@ restore a `PyLazyFrame` function) once a polars/toolchain combo builds it cleanl
 
 `pyo3/extension-module` is set only in `[tool.maturin]`, not in the crate's default
 features, because it suppresses libpython linking and breaks `cargo test`'s
-standalone binary. If `cargo test` can't find a Python to link, pass
-`PYO3_PYTHON=$(uv run which python)`.
+standalone binary. If `cargo test` can't find a Python to link against at *build*
+time, pass `PYO3_PYTHON=$(uv run which python)`.
+
+Separately, at *run* time the test binary dynamically links libpython but doesn't
+get an rpath to uv's managed Python install, so the runtime loader may not find it
+either (`error while loading shared libraries: libpython3.13.so.1.0` on Linux,
+`Library not loaded: .../libpython3.13.dylib` on macOS). Point the loader at it
+explicitly:
+
+```bash
+PYTHON_LIBDIR=$(uv run python -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))")
+LD_LIBRARY_PATH="$PYTHON_LIBDIR" cargo test --lib   # Linux
+DYLD_LIBRARY_PATH="$PYTHON_LIBDIR" cargo test --lib # macOS
+```
+
+CI (`.github/workflows/bioregion-rs.yml`) does this automatically.

--- a/bioregion_rs/README.md
+++ b/bioregion_rs/README.md
@@ -19,6 +19,9 @@ every subsequent file migration will use.
 - `harness.py` — runs each Rust function and its Python counterpart on the same
   input and asserts they match. The template for migrating each file.
 
+CI (`.github/workflows/bioregion-rs.yml`) runs `cargo test --lib`, builds the
+extension via `maturin develop`, and runs `harness.py` on every push.
+
 ## Build & test
 
 ```bash

--- a/bioregion_rs/harness.py
+++ b/bioregion_rs/harness.py
@@ -15,6 +15,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # Make the repo-root `src` package importable regardless of CWD.
 sys.path.insert(0, str(REPO_ROOT))
 
+import numpy as np
 import polars as pl
 import shapely
 
@@ -34,6 +35,7 @@ from src.geocode import (
     select_geocode_lf,
     with_geocode_lf,
 )
+from src.matrices.geocode_connectivity import GeocodeConnectivityMatrix
 from src.types import Bbox
 
 
@@ -307,6 +309,27 @@ def test_build_geocode_neighbors_no_edges() -> None:
     )
 
 
+# --- src/matrices/geocode_connectivity.py -------------------------------------
+
+
+def test_build_geocode_connectivity_matrix() -> None:
+    print("src/matrices/geocode_connectivity.py  (build_geocode_connectivity_matrix):")
+    bbox, precision, _darwin_lf, darwin_df, _geocode_no_edges_df = (
+        _load_bbox_darwin_and_geocode_no_edges()
+    )
+    geocode_df = build_geocode_df(darwin_df.lazy(), precision, bbox)
+    geocode_neighbors_df = build_geocode_neighbors_df(geocode_df)
+
+    rust_matrix = bioregion_rs.build_geocode_connectivity_matrix(geocode_neighbors_df)
+    py_matrix = GeocodeConnectivityMatrix.build(geocode_neighbors_df)._connectivity_matrix
+
+    check(f"non-trivial: {len(rust_matrix)}x{len(rust_matrix)} matrix", len(rust_matrix) > 1)
+    check(
+        "matrix matches exactly",
+        np.array(rust_matrix, dtype=int).tolist() == py_matrix.astype(int).tolist(),
+    )
+
+
 # --- parquet stage boundary --------------------------------------------------
 
 
@@ -333,6 +356,7 @@ def main() -> None:
     test_build_geocode_taxa_counts()
     test_build_geocode_neighbors()
     test_build_geocode_neighbors_no_edges()
+    test_build_geocode_connectivity_matrix()
     test_parquet_boundary()
     print("\nAll interop + correctness checks passed.")
 

--- a/bioregion_rs/src/lib.rs
+++ b/bioregion_rs/src/lib.rs
@@ -13,6 +13,7 @@ use pyo3::prelude::*;
 mod colors;
 mod dataframes;
 mod geocode;
+mod matrices;
 mod wkb;
 
 /// Convert a polars error into a Python `ValueError`.
@@ -38,6 +39,10 @@ fn bioregion_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     )?)?;
     m.add_function(wrap_pyfunction!(
         dataframes::geocode_neighbors::build_geocode_neighbors_no_edges,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(
+        matrices::geocode_connectivity::build_geocode_connectivity_matrix,
         m
     )?)?;
     Ok(())

--- a/bioregion_rs/src/matrices/geocode_connectivity.rs
+++ b/bioregion_rs/src/matrices/geocode_connectivity.rs
@@ -1,0 +1,112 @@
+//! Port of `src/matrices/geocode_connectivity.py`
+//! (`GeocodeConnectivityMatrix.build`).
+
+use std::collections::HashMap;
+
+use polars::prelude::*;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3_polars::PyDataFrame;
+
+use crate::to_py;
+
+/// BFS reachability check: is `matrix` (as an undirected adjacency matrix) a
+/// single connected component?
+fn is_single_connected_component(matrix: &[Vec<i64>]) -> bool {
+    let n = matrix.len();
+    if n == 0 {
+        return true;
+    }
+    let mut visited = vec![false; n];
+    let mut stack = vec![0usize];
+    visited[0] = true;
+    let mut count = 1;
+    while let Some(u) = stack.pop() {
+        for (v, &connected) in matrix[u].iter().enumerate() {
+            if connected != 0 && !visited[v] {
+                visited[v] = true;
+                count += 1;
+                stack.push(v);
+            }
+        }
+    }
+    count == n
+}
+
+/// Build a dense (num_geocodes x num_geocodes) 0/1 adjacency matrix from a
+/// GeocodeNeighborsSchema DataFrame's `direct_and_indirect_neighbors` column.
+///
+/// Mirrors `GeocodeConnectivityMatrix.build`: returned as a nested list (PyO3
+/// converts `Vec<Vec<i64>>` to a Python list of lists — note `Vec<u8>` would
+/// convert to Python `bytes` instead, which is why cells are `i64` rather than
+/// a narrower unsigned type), which the Python side wraps with `np.array(...)`
+/// to match the existing `GeocodeConnectivityMatrix` type (`dtype=int`, i.e.
+/// int64). Errors (instead of Python's `assert`) if the graph isn't a single
+/// connected component, since that invariant is expected to already hold by
+/// construction from `geocode_neighbors`.
+#[pyfunction]
+pub fn build_geocode_connectivity_matrix(
+    geocode_neighbors_df: PyDataFrame,
+) -> PyResult<Vec<Vec<i64>>> {
+    let df: DataFrame = geocode_neighbors_df.into();
+    let n = df.height();
+
+    let geocode_ca = df
+        .column("geocode")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .u64()
+        .map_err(to_py)?
+        .clone();
+    let neighbors_ca = df
+        .column("direct_and_indirect_neighbors")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .list()
+        .map_err(to_py)?
+        .clone();
+
+    let geocode_to_index: HashMap<u64, usize> = geocode_ca
+        .iter()
+        .enumerate()
+        .filter_map(|(i, g)| g.map(|g| (g, i)))
+        .collect();
+
+    let mut matrix = vec![vec![0i64; n]; n];
+    for i in 0..n {
+        let Some(series) = neighbors_ca.get_as_series(i) else {
+            continue;
+        };
+        let neighbors = series.u64().map_err(to_py)?;
+        for neighbor in neighbors.into_no_null_iter() {
+            if let Some(&j) = geocode_to_index.get(&neighbor) {
+                matrix[i][j] = 1;
+            }
+        }
+    }
+
+    if !is_single_connected_component(&matrix) {
+        return Err(PyValueError::new_err(
+            "geocode connectivity matrix is not a single connected component",
+        ));
+    }
+
+    Ok(matrix)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_disconnected_matrix() {
+        let matrix = vec![vec![0, 1, 0], vec![1, 0, 0], vec![0, 0, 0]];
+        assert!(!is_single_connected_component(&matrix));
+    }
+
+    #[test]
+    fn detects_connected_matrix() {
+        let matrix = vec![vec![0, 1, 0], vec![1, 0, 1], vec![0, 1, 0]];
+        assert!(is_single_connected_component(&matrix));
+    }
+}

--- a/bioregion_rs/src/matrices/mod.rs
+++ b/bioregion_rs/src/matrices/mod.rs
@@ -1,0 +1,3 @@
+//! Ports of `src/matrices/*.py`.
+
+pub mod geocode_connectivity;


### PR DESCRIPTION
## Summary
- Ports `src/matrices/geocode_connectivity.py::GeocodeConnectivityMatrix.build` to Rust (`build_geocode_connectivity_matrix` in `bioregion_rs`): builds the dense 0/1 adjacency matrix from a `GeocodeNeighborsSchema` DataFrame's `direct_and_indirect_neighbors` column, returned as a nested `Vec<Vec<i64>>` (no `ndarray`/`sprs` dependency needed) for the Python side to wrap with `np.array(...)`.
- The single-connected-component invariant is checked via a small BFS (instead of `networkx`) and raises a `ValueError` instead of Python's `assert`.
- **Adds `.github/workflows/bioregion-rs.yml`.** Until now nothing in CI actually built or exercised `bioregion_rs` — the pipeline's own CI (`run.yml`) runs `notebook.py` end-to-end in pure Python and doesn't invoke Rust at all, since no pipeline call site has switched over yet. The new job runs `cargo test --lib`, builds the extension via `maturin develop`, and runs `harness.py` on every push, so a Rust change that breaks parity with Python now fails CI instead of relying on someone running the harness locally.
- This closes out Phase 1's non-trivial files; only static-data leaves remain (`types.py`, `constants.py`, `defaults.py`, `country_bbox.py`).

## Test plan
- [x] `cargo test --lib` (7 tests pass)
- [x] `uv run maturin develop --manifest-path bioregion_rs/Cargo.toml`
- [x] `uv run python bioregion_rs/harness.py` (all checks pass, including the new `build_geocode_connectivity_matrix` check — exact matrix match against `GeocodeConnectivityMatrix.build`)
- [x] `uv run pyright` (0 errors)
- [x] New `bioregion-rs.yml` workflow (will run on this PR's push)

https://claude.ai/code/session_01XefuZ41iibHEgQrxWiqDjg