### PR TITLE
Phase 2: port cluster_taxa_statistics.py to Rust

### DIFF
--- a/RUST_MIGRATION_PLAN.md
+++ b/RUST_MIGRATION_PLAN.md
@@ -250,7 +250,15 @@ validated).
 
 ### Phase 2 — graph, geometry, and stats (⚠️ ported algorithms)
 
-- `src/dataframes/cluster_taxa_statistics.py` — per-cluster taxon aggregation. ✅
+- `src/dataframes/cluster_taxa_statistics.py` — ✅ DONE: `build_cluster_taxa_statistics`
+  (per-taxon count/average, overall and per cluster). Same eager, hand-rolled
+  join/group-by pattern as Phase 1 (`HashMap`s, no `polars-ops`): the join against
+  `taxonomy_df` is really just a semi-filter (taxonId is a unique key there, so it
+  never fans out rows and no taxonomy column is used downstream), and the join
+  against the geocode→cluster mapping is a real inner join, implemented as a
+  `HashMap<geocode, cluster>` lookup. Verified against Python by comparing
+  `(cluster, taxonId, count, average)` as a row set, using a synthetic geocode→cluster
+  assignment in the harness since real clustering (sklearn Ward) is Phase 3.
 - `src/dataframes/cluster_neighbors.py` — build cluster adjacency graph, connected
   components / neighbor expansion. `petgraph`. moderate
 - `src/matrices/cluster_distance.py` — braycurtis `pdist` over cluster taxon vectors.

--- a/bioregion_rs/README.md
+++ b/bioregion_rs/README.md
@@ -16,6 +16,8 @@ every subsequent file migration will use.
   - `build_geocode_taxa_counts` — mirrors `src/dataframes/geocode_taxa_counts.py`.
   - `build_geocode_neighbors`/`build_geocode_neighbors_no_edges` — mirrors
     `src/dataframes/geocode_neighbors.py`.
+  - `build_geocode_connectivity_matrix` — mirrors `src/matrices/geocode_connectivity.py`.
+  - `build_cluster_taxa_statistics` — mirrors `src/dataframes/cluster_taxa_statistics.py`.
 - `harness.py` — runs each Rust function and its Python counterpart on the same
   input and asserts they match. The template for migrating each file.
 

--- a/bioregion_rs/harness.py
+++ b/bioregion_rs/harness.py
@@ -21,6 +21,7 @@ import shapely
 
 import bioregion_rs
 from src.colors import darken_hex_color as py_darken
+from src.dataframes.cluster_taxa_statistics import build_cluster_taxa_statistics_df
 from src.dataframes.darwin_core import build_darwin_core_lf
 from src.dataframes.geocode import build_geocode_df
 from src.dataframes.geocode_neighbors import (
@@ -330,6 +331,50 @@ def test_build_geocode_connectivity_matrix() -> None:
     )
 
 
+# --- src/dataframes/cluster_taxa_statistics.py --------------------------------
+
+
+def test_build_cluster_taxa_statistics() -> None:
+    print("src/dataframes/cluster_taxa_statistics.py  (build_cluster_taxa_statistics):")
+    bbox, precision, _darwin_lf, darwin_df, geocode_no_edges_df = (
+        _load_bbox_darwin_and_geocode_no_edges()
+    )
+    py_taxonomy = build_taxonomy_lf(
+        darwin_df.lazy(), precision, geocode_no_edges_df.lazy(), bbox
+    ).collect()
+    py_counts = build_geocode_taxa_counts_lf(
+        darwin_df.lazy(), precision, py_taxonomy.lazy(), geocode_no_edges_df.lazy(), bbox
+    ).collect()
+
+    # Synthetic cluster assignment (real clustering is sklearn Ward
+    # agglomerative clustering, out of scope for this port): split geocodes
+    # into two clusters deterministically so both the overall and per-cluster
+    # aggregation paths get exercised.
+    geocodes = py_counts["geocode"].unique().sort()
+    geocode_cluster_df = pl.DataFrame(
+        {"geocode": geocodes, "cluster": [g % 2 for g in geocodes]}
+    ).cast({"geocode": pl.UInt64, "cluster": pl.UInt32})
+
+    rust_out = bioregion_rs.build_cluster_taxa_statistics(
+        py_counts, geocode_cluster_df, py_taxonomy
+    )
+    py_out = build_cluster_taxa_statistics_df(
+        py_counts.lazy(), geocode_cluster_df.lazy(), py_taxonomy.lazy()
+    )
+
+    check(f"non-trivial: {py_out.height} rows", py_out.height > 0)
+
+    def _rows(df: pl.DataFrame) -> set:
+        return {
+            (cluster, taxon_id, count, round(average, 9))
+            for cluster, taxon_id, count, average in df.select(
+                "cluster", "taxonId", "count", "average"
+            ).iter_rows()
+        }
+
+    check("same (cluster, taxonId, count, average) row set", _rows(rust_out) == _rows(py_out))
+
+
 # --- parquet stage boundary --------------------------------------------------
 
 
@@ -357,6 +402,7 @@ def main() -> None:
     test_build_geocode_neighbors()
     test_build_geocode_neighbors_no_edges()
     test_build_geocode_connectivity_matrix()
+    test_build_cluster_taxa_statistics()
     test_parquet_boundary()
     print("\nAll interop + correctness checks passed.")
 

--- a/bioregion_rs/src/dataframes/cluster_taxa_statistics.rs
+++ b/bioregion_rs/src/dataframes/cluster_taxa_statistics.rs
@@ -1,0 +1,142 @@
+//! Port of `src/dataframes/cluster_taxa_statistics.py`
+//! (`build_cluster_taxa_statistics_df`).
+
+use std::collections::HashMap;
+
+use polars::prelude::*;
+use pyo3::prelude::*;
+use pyo3_polars::PyDataFrame;
+
+use crate::to_py;
+
+/// Column-major (geocode, taxonId, count) view of a GeocodeTaxaCountsSchema
+/// DataFrame.
+fn geocode_taxon_counts(df: &DataFrame) -> PolarsResult<Vec<(u64, u32, u32)>> {
+    let geocode = df
+        .column("geocode")?
+        .as_materialized_series()
+        .u64()?
+        .clone();
+    let taxon_id = df
+        .column("taxonId")?
+        .as_materialized_series()
+        .u32()?
+        .clone();
+    let count = df.column("count")?.as_materialized_series().u32()?.clone();
+    Ok(geocode
+        .into_no_null_iter()
+        .zip(taxon_id.into_no_null_iter())
+        .zip(count.into_no_null_iter())
+        .map(|((g, t), c)| (g, t, c))
+        .collect())
+}
+
+/// Build a ClusterTaxaStatisticsSchema DataFrame: per-taxon (count, average)
+/// stats overall (`cluster = null`) and per cluster.
+///
+/// Mirrors `build_cluster_taxa_statistics_df`. The join against `taxonomy_df`
+/// (on `taxonId`) only ever narrows `geocode_taxa_counts_df` to rows whose
+/// `taxonId` taxonomy_df actually has (taxonId is a unique key there), so it's
+/// implemented as a semi-filter rather than a real join — no taxonomy column
+/// is otherwise used downstream.
+#[pyfunction]
+pub fn build_cluster_taxa_statistics(
+    geocode_taxa_counts_df: PyDataFrame,
+    geocode_cluster_df: PyDataFrame,
+    taxonomy_df: PyDataFrame,
+) -> PyResult<PyDataFrame> {
+    let geocode_taxa_counts_df: DataFrame = geocode_taxa_counts_df.into();
+    let geocode_cluster_df: DataFrame = geocode_cluster_df.into();
+    let taxonomy_df: DataFrame = taxonomy_df.into();
+
+    let taxonomy_taxon_ids: std::collections::HashSet<u32> = taxonomy_df
+        .column("taxonId")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .u32()
+        .map_err(to_py)?
+        .into_no_null_iter()
+        .collect();
+
+    let joined: Vec<(u64, u32, u32)> = geocode_taxon_counts(&geocode_taxa_counts_df)
+        .map_err(to_py)?
+        .into_iter()
+        .filter(|&(_, taxon_id, _)| taxonomy_taxon_ids.contains(&taxon_id))
+        .collect();
+
+    let total_count: u64 = joined.iter().map(|&(_, _, count)| u64::from(count)).sum();
+
+    // Overall stats (cluster = null): sum(count) and average per taxonId.
+    let mut overall_counts: HashMap<u32, u64> = HashMap::new();
+    for &(_, taxon_id, count) in &joined {
+        *overall_counts.entry(taxon_id).or_default() += u64::from(count);
+    }
+
+    let mut clusters: Vec<Option<u32>> = Vec::new();
+    let mut taxon_ids: Vec<u32> = Vec::new();
+    let mut counts: Vec<u32> = Vec::new();
+    let mut averages: Vec<f64> = Vec::new();
+
+    for (&taxon_id, &count) in &overall_counts {
+        clusters.push(None);
+        taxon_ids.push(taxon_id);
+        counts.push(count as u32);
+        averages.push(count as f64 / total_count as f64);
+    }
+
+    // Per-cluster stats: only geocodes present in geocode_cluster_df (an
+    // inner join on geocode).
+    let geocode_to_cluster: HashMap<u64, u32> = {
+        let geocode = geocode_cluster_df
+            .column("geocode")
+            .map_err(to_py)?
+            .as_materialized_series()
+            .u64()
+            .map_err(to_py)?
+            .clone();
+        let cluster = geocode_cluster_df
+            .column("cluster")
+            .map_err(to_py)?
+            .as_materialized_series()
+            .u32()
+            .map_err(to_py)?
+            .clone();
+        geocode
+            .into_no_null_iter()
+            .zip(cluster.into_no_null_iter())
+            .collect()
+    };
+
+    let mut cluster_totals: HashMap<u32, u64> = HashMap::new();
+    let mut cluster_taxon_counts: HashMap<(u32, u32), u64> = HashMap::new();
+    for &(geocode, taxon_id, count) in &joined {
+        let Some(&cluster) = geocode_to_cluster.get(&geocode) else {
+            continue;
+        };
+        *cluster_totals.entry(cluster).or_default() += u64::from(count);
+        *cluster_taxon_counts.entry((cluster, taxon_id)).or_default() += u64::from(count);
+    }
+
+    for (&(cluster, taxon_id), &count) in &cluster_taxon_counts {
+        let total_in_cluster = cluster_totals[&cluster];
+        clusters.push(Some(cluster));
+        taxon_ids.push(taxon_id);
+        counts.push(count as u32);
+        averages.push(count as f64 / total_in_cluster as f64);
+    }
+
+    let height = clusters.len();
+    let cluster_col: UInt32Chunked = clusters.into_iter().collect();
+    let out = DataFrame::new(
+        height,
+        vec![
+            cluster_col.with_name("cluster".into()).into_column(),
+            UInt32Chunked::from_vec("taxonId".into(), taxon_ids).into_column(),
+            UInt32Chunked::from_vec("count".into(), counts).into_column(),
+            Float64Chunked::from_vec("average".into(), averages).into_column(),
+        ],
+    )
+    .map_err(to_py)?;
+
+    Ok(PyDataFrame(out))
+}

--- a/bioregion_rs/src/dataframes/mod.rs
+++ b/bioregion_rs/src/dataframes/mod.rs
@@ -1,5 +1,6 @@
 //! Ports of `src/dataframes/*.py`.
 
+pub mod cluster_taxa_statistics;
 pub mod geocode;
 pub mod geocode_neighbors;
 pub mod geocode_taxa_counts;

--- a/bioregion_rs/src/lib.rs
+++ b/bioregion_rs/src/lib.rs
@@ -45,5 +45,9 @@ fn bioregion_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
         matrices::geocode_connectivity::build_geocode_connectivity_matrix,
         m
     )?)?;
+    m.add_function(wrap_pyfunction!(
+        dataframes::cluster_taxa_statistics::build_cluster_taxa_statistics,
+        m
+    )?)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- First Phase 2 port: `src/dataframes/cluster_taxa_statistics.py::build_cluster_taxa_statistics_df` → `build_cluster_taxa_statistics` in `bioregion_rs`.
- Computes per-taxon (count, average) stats overall (`cluster = null`) and per cluster, from a `GeocodeTaxaCountsSchema` DataFrame, a geocode→cluster mapping, and the taxonomy table.
- Same eager, hand-rolled join/group-by pattern established in Phase 1 (`HashMap`s, no `polars-ops`/lazy):
  - The join against `taxonomy_df` (on `taxonId`) is implemented as a semi-filter, since `taxonId` is a unique key there — it never fans out rows and no taxonomy column is used downstream.
  - The join against the geocode→cluster mapping is a real inner join, done via a `HashMap<geocode, cluster>` lookup.
- Verified against Python in `harness.py` using a synthetic geocode→cluster assignment (real clustering is sklearn Ward agglomerative clustering — Phase 3, out of scope here) — compares `(cluster, taxonId, count, average)` as a row set.

## Test plan
- [x] `cargo test --lib` (7 tests pass)
- [x] `uv run maturin develop --manifest-path bioregion_rs/Cargo.toml`
- [x] `uv run python bioregion_rs/harness.py` (all checks pass, including the new `build_cluster_taxa_statistics` check)
- [x] `uv run pyright` (0 errors)
- [x] bioregion_rs CI job (added in #12) will run on this PR's push

https://claude.ai/code/session_01XefuZ41iibHEgQrxWiqDjg