### PR TITLE
Phase 2: port cluster_neighbors.py to Rust

### DIFF
--- a/RUST_MIGRATION_PLAN.md
+++ b/RUST_MIGRATION_PLAN.md
@@ -259,8 +259,16 @@ validated).
   `HashMap<geocode, cluster>` lookup. Verified against Python by comparing
   `(cluster, taxonId, count, average)` as a row set, using a synthetic geocode→cluster
   assignment in the harness since real clustering (sklearn Ward) is Phase 3.
-- `src/dataframes/cluster_neighbors.py` — build cluster adjacency graph, connected
-  components / neighbor expansion. `petgraph`. moderate
+- `src/dataframes/cluster_neighbors.py` — ✅ DONE: `build_cluster_neighbors` derives
+  which clusters are (direct/indirect) neighbors of each other from geocode-level
+  adjacency plus a geocode→cluster mapping. Turned out not to need `petgraph` or any
+  connected-components logic at all — it's a pure derivation (for each geocode's
+  neighbors, note the pair of clusters if they differ), done with a
+  `HashMap<geocode, cluster>` lookup. Mirrors Python's fail-fast behavior (errors
+  instead of silently skipping) if a geocode is missing from the cluster mapping. The
+  `to_graph()` helper (produces an `nx.Graph`) stays in Python, same reasoning as
+  `geocode_neighbors.graph()`. Verified against Python by comparing neighbor sets per
+  cluster, using a synthetic geocode→cluster assignment (Phase 3, out of scope here).
 - `src/matrices/cluster_distance.py` — braycurtis `pdist` over cluster taxon vectors.
   Simple port. ✅
 - `src/dataframes/cluster_color.py` **(geographic path only)** — `nx.greedy_color` →

--- a/bioregion_rs/README.md
+++ b/bioregion_rs/README.md
@@ -18,6 +18,7 @@ every subsequent file migration will use.
     `src/dataframes/geocode_neighbors.py`.
   - `build_geocode_connectivity_matrix` — mirrors `src/matrices/geocode_connectivity.py`.
   - `build_cluster_taxa_statistics` — mirrors `src/dataframes/cluster_taxa_statistics.py`.
+  - `build_cluster_neighbors` — mirrors `src/dataframes/cluster_neighbors.py`.
 - `harness.py` — runs each Rust function and its Python counterpart on the same
   input and asserts they match. The template for migrating each file.
 

--- a/bioregion_rs/harness.py
+++ b/bioregion_rs/harness.py
@@ -21,6 +21,7 @@ import shapely
 
 import bioregion_rs
 from src.colors import darken_hex_color as py_darken
+from src.dataframes.cluster_neighbors import build_cluster_neighbors_df
 from src.dataframes.cluster_taxa_statistics import build_cluster_taxa_statistics_df
 from src.dataframes.darwin_core import build_darwin_core_lf
 from src.dataframes.geocode import build_geocode_df
@@ -245,8 +246,8 @@ def test_build_geocode_taxa_counts() -> None:
 # --- src/dataframes/geocode_neighbors.py --------------------------------------
 
 
-def _neighbor_sets(df: pl.DataFrame, column: str) -> dict:
-    return {geocode: set(neighbors) for geocode, neighbors in df.select("geocode", column).iter_rows()}
+def _neighbor_sets(df: pl.DataFrame, column: str, key: str = "geocode") -> dict:
+    return {k: set(neighbors) for k, neighbors in df.select(key, column).iter_rows()}
 
 
 def _is_single_component(df: pl.DataFrame, include_indirect_neighbors: bool) -> bool:
@@ -375,6 +376,45 @@ def test_build_cluster_taxa_statistics() -> None:
     check("same (cluster, taxonId, count, average) row set", _rows(rust_out) == _rows(py_out))
 
 
+# --- src/dataframes/cluster_neighbors.py --------------------------------------
+
+
+def test_build_cluster_neighbors() -> None:
+    print("src/dataframes/cluster_neighbors.py  (build_cluster_neighbors):")
+    bbox, precision, _darwin_lf, darwin_df, geocode_no_edges_df = (
+        _load_bbox_darwin_and_geocode_no_edges()
+    )
+    geocode_df = build_geocode_df(darwin_df.lazy(), precision, bbox)
+    py_neighbors = build_geocode_neighbors_df(geocode_df)
+    py_neighbors_no_edges = build_geocode_neighbors_no_edges_df(
+        py_neighbors, geocode_no_edges_df
+    )
+
+    # Synthetic cluster assignment covering every geocode in the no-edges
+    # neighbor set (real clustering is sklearn Ward, out of scope here): split
+    # into 3 clusters deterministically so cross-cluster adjacency actually
+    # gets exercised.
+    geocodes = py_neighbors_no_edges["geocode"].sort()
+    geocode_cluster_df = pl.DataFrame(
+        {"geocode": geocodes, "cluster": [g % 3 for g in geocodes]}
+    ).cast({"geocode": pl.UInt64, "cluster": pl.UInt32})
+
+    rust_out = bioregion_rs.build_cluster_neighbors(py_neighbors_no_edges, geocode_cluster_df)
+    py_out = build_cluster_neighbors_df(py_neighbors_no_edges, geocode_cluster_df)
+
+    check(f"non-trivial: {py_out.height} clusters", py_out.height > 1)
+    check(
+        "same direct_neighbors set per cluster",
+        _neighbor_sets(rust_out, "direct_neighbors", key="cluster")
+        == _neighbor_sets(py_out, "direct_neighbors", key="cluster"),
+    )
+    check(
+        "same direct_and_indirect_neighbors set per cluster",
+        _neighbor_sets(rust_out, "direct_and_indirect_neighbors", key="cluster")
+        == _neighbor_sets(py_out, "direct_and_indirect_neighbors", key="cluster"),
+    )
+
+
 # --- parquet stage boundary --------------------------------------------------
 
 
@@ -403,6 +443,7 @@ def main() -> None:
     test_build_geocode_neighbors_no_edges()
     test_build_geocode_connectivity_matrix()
     test_build_cluster_taxa_statistics()
+    test_build_cluster_neighbors()
     test_parquet_boundary()
     print("\nAll interop + correctness checks passed.")
 

--- a/bioregion_rs/src/dataframes/cluster_neighbors.rs
+++ b/bioregion_rs/src/dataframes/cluster_neighbors.rs
@@ -1,0 +1,160 @@
+//! Port of `src/dataframes/cluster_neighbors.py` (`build_cluster_neighbors_df`).
+
+use std::collections::{BTreeSet, HashMap, HashSet};
+
+use polars::prelude::*;
+use pyo3::prelude::*;
+use pyo3_polars::PyDataFrame;
+
+use crate::to_py;
+
+/// Look up the cluster for a geocode, erroring (mirroring Python's
+/// `cluster_for_geocode`, which raises `IndexError` on a missing geocode)
+/// rather than silently skipping.
+fn cluster_of(map: &HashMap<u64, u32>, geocode: u64) -> PolarsResult<u32> {
+    map.get(&geocode).copied().ok_or_else(|| {
+        PolarsError::ComputeError(
+            format!("geocode {geocode} not found in geocode_cluster_df").into(),
+        )
+    })
+}
+
+/// Build a ClusterNeighborsSchema DataFrame: which clusters are (direct and
+/// indirect) neighbors of each other, derived from geocode-level adjacency.
+///
+/// Mirrors `build_cluster_neighbors_df`.
+#[pyfunction]
+pub fn build_cluster_neighbors(
+    geocode_neighbors_df: PyDataFrame,
+    geocode_cluster_df: PyDataFrame,
+) -> PyResult<PyDataFrame> {
+    let geocode_neighbors_df: DataFrame = geocode_neighbors_df.into();
+    let geocode_cluster_df: DataFrame = geocode_cluster_df.into();
+
+    let geocode_to_cluster: HashMap<u64, u32> = {
+        let geocode = geocode_cluster_df
+            .column("geocode")
+            .map_err(to_py)?
+            .as_materialized_series()
+            .u64()
+            .map_err(to_py)?
+            .clone();
+        let cluster = geocode_cluster_df
+            .column("cluster")
+            .map_err(to_py)?
+            .as_materialized_series()
+            .u32()
+            .map_err(to_py)?
+            .clone();
+        geocode
+            .into_no_null_iter()
+            .zip(cluster.into_no_null_iter())
+            .collect()
+    };
+
+    let unique_clusters: BTreeSet<u32> = geocode_to_cluster.values().copied().collect();
+    let mut direct_neighbors_map: HashMap<u32, HashSet<u32>> = unique_clusters
+        .iter()
+        .map(|&c| (c, HashSet::new()))
+        .collect();
+    let mut all_neighbors_map: HashMap<u32, HashSet<u32>> = unique_clusters
+        .iter()
+        .map(|&c| (c, HashSet::new()))
+        .collect();
+
+    let geocode_ca = geocode_neighbors_df
+        .column("geocode")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .u64()
+        .map_err(to_py)?
+        .clone();
+    let direct_ca = geocode_neighbors_df
+        .column("direct_neighbors")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .list()
+        .map_err(to_py)?
+        .clone();
+    let direct_and_indirect_ca = geocode_neighbors_df
+        .column("direct_and_indirect_neighbors")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .list()
+        .map_err(to_py)?
+        .clone();
+
+    for i in 0..geocode_neighbors_df.height() {
+        let Some(geocode) = geocode_ca.get(i) else {
+            continue;
+        };
+        let current_cluster = cluster_of(&geocode_to_cluster, geocode).map_err(to_py)?;
+
+        if let Some(series) = direct_ca.get_as_series(i) {
+            for neighbor in series.u64().map_err(to_py)?.into_no_null_iter() {
+                let neighbor_cluster = cluster_of(&geocode_to_cluster, neighbor).map_err(to_py)?;
+                if neighbor_cluster != current_cluster {
+                    direct_neighbors_map
+                        .get_mut(&current_cluster)
+                        .expect("cluster set initialized for every unique cluster")
+                        .insert(neighbor_cluster);
+                    all_neighbors_map
+                        .get_mut(&current_cluster)
+                        .expect("cluster set initialized for every unique cluster")
+                        .insert(neighbor_cluster);
+                }
+            }
+        }
+
+        if let Some(series) = direct_and_indirect_ca.get_as_series(i) {
+            for neighbor in series.u64().map_err(to_py)?.into_no_null_iter() {
+                let neighbor_cluster = cluster_of(&geocode_to_cluster, neighbor).map_err(to_py)?;
+                if neighbor_cluster != current_cluster {
+                    all_neighbors_map
+                        .get_mut(&current_cluster)
+                        .expect("cluster set initialized for every unique cluster")
+                        .insert(neighbor_cluster);
+                }
+            }
+        }
+    }
+
+    let n = unique_clusters.len();
+    let cluster_col =
+        UInt32Chunked::from_vec("cluster".into(), unique_clusters.iter().copied().collect())
+            .into_column();
+
+    let mut direct_builder = ListPrimitiveChunkedBuilder::<UInt32Type>::new(
+        "direct_neighbors".into(),
+        n,
+        n,
+        DataType::UInt32,
+    );
+    let mut direct_and_indirect_builder = ListPrimitiveChunkedBuilder::<UInt32Type>::new(
+        "direct_and_indirect_neighbors".into(),
+        n,
+        n,
+        DataType::UInt32,
+    );
+    for &cluster in &unique_clusters {
+        let direct: Vec<u32> = direct_neighbors_map[&cluster].iter().copied().collect();
+        let all: Vec<u32> = all_neighbors_map[&cluster].iter().copied().collect();
+        direct_builder.append_slice(&direct);
+        direct_and_indirect_builder.append_slice(&all);
+    }
+
+    let out = DataFrame::new(
+        n,
+        vec![
+            cluster_col,
+            direct_builder.finish().into_series().into_column(),
+            direct_and_indirect_builder
+                .finish()
+                .into_series()
+                .into_column(),
+        ],
+    )
+    .map_err(to_py)?;
+
+    Ok(PyDataFrame(out))
+}

--- a/bioregion_rs/src/dataframes/mod.rs
+++ b/bioregion_rs/src/dataframes/mod.rs
@@ -1,5 +1,6 @@
 //! Ports of `src/dataframes/*.py`.
 
+pub mod cluster_neighbors;
 pub mod cluster_taxa_statistics;
 pub mod geocode;
 pub mod geocode_neighbors;

--- a/bioregion_rs/src/lib.rs
+++ b/bioregion_rs/src/lib.rs
@@ -49,5 +49,9 @@ fn bioregion_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
         dataframes::cluster_taxa_statistics::build_cluster_taxa_statistics,
         m
     )?)?;
+    m.add_function(wrap_pyfunction!(
+        dataframes::cluster_neighbors::build_cluster_neighbors,
+        m
+    )?)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Ports `src/dataframes/cluster_neighbors.py::build_cluster_neighbors_df` to Rust (`build_cluster_neighbors` in `bioregion_rs`).
- Derives which clusters are direct/indirect neighbors of each other from geocode-level adjacency (`GeocodeNeighborsSchema`) plus a geocode→cluster mapping.
- The plan flagged this as needing `petgraph` for connected components, but it turned out not to need any graph algorithm at all — it's a pure derivation (for each geocode's neighbors, note the pair of clusters when they differ), done with a `HashMap<geocode, cluster>` lookup.
- Mirrors Python's fail-fast behavior: errors (instead of silently skipping) if a geocode is missing from the cluster mapping, matching `cluster_for_geocode`'s `IndexError`.
- The `to_graph()` helper (builds an `nx.Graph` for downstream consumers) stays in Python, same reasoning as `geocode_neighbors.graph()` — thin, networkx-object-specific wrapper.
- Verified against Python in `harness.py` using a synthetic geocode→cluster assignment (real clustering is sklearn Ward — Phase 3, out of scope here).

## Test plan
- [x] `cargo test --lib` (7 tests pass)
- [x] `uv run maturin develop --manifest-path bioregion_rs/Cargo.toml`
- [x] `uv run python bioregion_rs/harness.py` (all checks pass, including the new `build_cluster_neighbors` check)
- [x] `uv run pyright` (0 errors)
- [x] bioregion_rs CI job will run on this PR's push

https://claude.ai/code/session_01XefuZ41iibHEgQrxWiqDjg