### PR TITLE
Phase 2: port cluster_distance.py to Rust

### DIFF
--- a/RUST_MIGRATION_PLAN.md
+++ b/RUST_MIGRATION_PLAN.md
@@ -269,8 +269,24 @@ validated).
   `to_graph()` helper (produces an `nx.Graph`) stays in Python, same reasoning as
   `geocode_neighbors.graph()`. Verified against Python by comparing neighbor sets per
   cluster, using a synthetic geocode→cluster assignment (Phase 3, out of scope here).
-- `src/matrices/cluster_distance.py` — braycurtis `pdist` over cluster taxon vectors.
-  Simple port. ✅
+- `src/matrices/cluster_distance.py` — ✅ DONE: `build_cluster_distance_matrix`.
+  Unlike `geocode_distance.py` (Phase 3), this file has **no UMAP step** — it's just
+  `RobustScaler` (median/IQR per column, hand-ported: numpy's linear-interpolation
+  percentile, IQR-of-0 leaves a column unscaled per sklearn's documented behavior) then
+  `pdist(metric="braycurtis")`, both fully portable, so this is a complete port, not
+  scaffolding for later. Returns a condensed (scipy `pdist`-order) distance vector plus
+  the cluster IDs in row order, rather than a `ClusterDistanceMatrix` object — row/column
+  order doesn't need to match Python's `pivot()` exactly, since both RobustScaler
+  (per-column) and Bray-Curtis (order-invariant sums) give identical distances under any
+  *consistent* column permutation. Verified against `ClusterDistanceMatrix.build` by
+  looking up pairwise distances by cluster-ID pair (order-independent). **Caveat found
+  while testing:** with exactly 2 clusters, RobustScaler always scales every non-constant
+  column to a perfect ±1 pair, making Bray-Curtis's `sum(|u+v|)` denominator ~0 for every
+  such column — the distance becomes a huge, floating-point-rounding-dominated number
+  that two independent implementations have no reason to agree on bit-for-bit. This is a
+  property of the algorithm at k=2, not a port bug; the harness test uses more clusters
+  to avoid it, but real runs with `min_clusters=2` could hit this instability in Python
+  today too.
 - `src/dataframes/cluster_color.py` **(geographic path only)** — `nx.greedy_color` →
   `petgraph`'s greedy coloring; palette mapping is deterministic. ✅
   (Taxonomic path uses UMAP+MDS — see Phase 3.)

--- a/bioregion_rs/README.md
+++ b/bioregion_rs/README.md
@@ -19,6 +19,7 @@ every subsequent file migration will use.
   - `build_geocode_connectivity_matrix` — mirrors `src/matrices/geocode_connectivity.py`.
   - `build_cluster_taxa_statistics` — mirrors `src/dataframes/cluster_taxa_statistics.py`.
   - `build_cluster_neighbors` — mirrors `src/dataframes/cluster_neighbors.py`.
+  - `build_cluster_distance_matrix` — mirrors `src/matrices/cluster_distance.py`.
 - `harness.py` — runs each Rust function and its Python counterpart on the same
   input and asserts they match. The template for migrating each file.
 

--- a/bioregion_rs/harness.py
+++ b/bioregion_rs/harness.py
@@ -18,6 +18,7 @@ sys.path.insert(0, str(REPO_ROOT))
 import numpy as np
 import polars as pl
 import shapely
+from scipy.spatial.distance import squareform
 
 import bioregion_rs
 from src.colors import darken_hex_color as py_darken
@@ -37,6 +38,7 @@ from src.geocode import (
     select_geocode_lf,
     with_geocode_lf,
 )
+from src.matrices.cluster_distance import ClusterDistanceMatrix
 from src.matrices.geocode_connectivity import GeocodeConnectivityMatrix
 from src.types import Bbox
 
@@ -351,9 +353,11 @@ def test_build_cluster_taxa_statistics() -> None:
     # agglomerative clustering, out of scope for this port): split geocodes
     # into two clusters deterministically so both the overall and per-cluster
     # aggregation paths get exercised.
+    # Cluster by row index (not geocode value) since H3 cell IDs at a given
+    # resolution can share low-order bits, making `geocode % k` degenerate.
     geocodes = py_counts["geocode"].unique().sort()
     geocode_cluster_df = pl.DataFrame(
-        {"geocode": geocodes, "cluster": [g % 2 for g in geocodes]}
+        {"geocode": geocodes, "cluster": [i % 2 for i in range(len(geocodes))]}
     ).cast({"geocode": pl.UInt64, "cluster": pl.UInt32})
 
     rust_out = bioregion_rs.build_cluster_taxa_statistics(
@@ -390,13 +394,13 @@ def test_build_cluster_neighbors() -> None:
         py_neighbors, geocode_no_edges_df
     )
 
-    # Synthetic cluster assignment covering every geocode in the no-edges
-    # neighbor set (real clustering is sklearn Ward, out of scope here): split
-    # into 3 clusters deterministically so cross-cluster adjacency actually
-    # gets exercised.
+    # Cluster by row index (not geocode value) since H3 cell IDs at a given
+    # resolution can share low-order bits, making `geocode % k` degenerate.
+    # Real clustering is sklearn Ward, out of scope here; 3 clusters so
+    # cross-cluster adjacency actually gets exercised.
     geocodes = py_neighbors_no_edges["geocode"].sort()
     geocode_cluster_df = pl.DataFrame(
-        {"geocode": geocodes, "cluster": [g % 3 for g in geocodes]}
+        {"geocode": geocodes, "cluster": [i % 3 for i in range(len(geocodes))]}
     ).cast({"geocode": pl.UInt64, "cluster": pl.UInt32})
 
     rust_out = bioregion_rs.build_cluster_neighbors(py_neighbors_no_edges, geocode_cluster_df)
@@ -412,6 +416,65 @@ def test_build_cluster_neighbors() -> None:
         "same direct_and_indirect_neighbors set per cluster",
         _neighbor_sets(rust_out, "direct_and_indirect_neighbors", key="cluster")
         == _neighbor_sets(py_out, "direct_and_indirect_neighbors", key="cluster"),
+    )
+
+
+# --- src/matrices/cluster_distance.py -----------------------------------------
+
+
+def _pairwise_distances(condensed, cluster_ids) -> dict:
+    square = squareform(np.asarray(condensed))
+    return {
+        tuple(sorted((c1, c2))): round(float(square[i][j]), 9)
+        for i, c1 in enumerate(cluster_ids)
+        for j, c2 in enumerate(cluster_ids)
+        if i < j
+    }
+
+
+def test_build_cluster_distance_matrix() -> None:
+    print("src/matrices/cluster_distance.py  (build_cluster_distance_matrix):")
+    bbox, precision, _darwin_lf, darwin_df, geocode_no_edges_df = (
+        _load_bbox_darwin_and_geocode_no_edges()
+    )
+    py_taxonomy = build_taxonomy_lf(
+        darwin_df.lazy(), precision, geocode_no_edges_df.lazy(), bbox
+    ).collect()
+    py_counts = build_geocode_taxa_counts_lf(
+        darwin_df.lazy(), precision, py_taxonomy.lazy(), geocode_no_edges_df.lazy(), bbox
+    ).collect()
+
+    # Cluster by row index (not geocode value) since H3 cell IDs at a given
+    # resolution can share low-order bits, making `geocode % k` degenerate.
+    # Real clustering is sklearn Ward, out of scope here. Use one cluster per
+    # geocode (not just 2): with exactly 2 clusters, RobustScaler always
+    # scales every non-constant column to a perfect +-1 pair, so Bray-Curtis's
+    # sum(|u+v|) denominator is ~0 for every such column and the distance
+    # becomes a huge, rounding-dominated number that two independent
+    # implementations have no reason to agree on bit-for-bit.
+    geocodes = py_counts["geocode"].unique().sort()
+    n = len(geocodes)
+    geocode_cluster_df = pl.DataFrame(
+        {"geocode": geocodes, "cluster": list(range(n))}
+    ).cast({"geocode": pl.UInt64, "cluster": pl.UInt32})
+    cluster_taxa_stats = build_cluster_taxa_statistics_df(
+        py_counts.lazy(), geocode_cluster_df.lazy(), py_taxonomy.lazy()
+    )
+
+    rust_condensed, rust_cluster_ids = bioregion_rs.build_cluster_distance_matrix(
+        cluster_taxa_stats
+    )
+    py_matrix = ClusterDistanceMatrix.build(cluster_taxa_stats)
+
+    check(f"non-trivial: {len(rust_cluster_ids)} clusters", len(rust_cluster_ids) > 1)
+
+    rust_distances = _pairwise_distances(rust_condensed, rust_cluster_ids)
+    py_distances = _pairwise_distances(py_matrix.condensed(), py_matrix.cluster_ids())
+
+    check("same cluster ID pairs", set(rust_distances) == set(py_distances))
+    check(
+        "same pairwise Bray-Curtis distances",
+        all(abs(rust_distances[k] - py_distances[k]) < 1e-9 for k in rust_distances),
     )
 
 
@@ -444,6 +507,7 @@ def main() -> None:
     test_build_geocode_connectivity_matrix()
     test_build_cluster_taxa_statistics()
     test_build_cluster_neighbors()
+    test_build_cluster_distance_matrix()
     test_parquet_boundary()
     print("\nAll interop + correctness checks passed.")
 

--- a/bioregion_rs/src/lib.rs
+++ b/bioregion_rs/src/lib.rs
@@ -53,5 +53,9 @@ fn bioregion_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
         dataframes::cluster_neighbors::build_cluster_neighbors,
         m
     )?)?;
+    m.add_function(wrap_pyfunction!(
+        matrices::cluster_distance::build_cluster_distance_matrix,
+        m
+    )?)?;
     Ok(())
 }

--- a/bioregion_rs/src/matrices/cluster_distance.rs
+++ b/bioregion_rs/src/matrices/cluster_distance.rs
@@ -1,0 +1,183 @@
+//! Port of `src/matrices/cluster_distance.py` (`ClusterDistanceMatrix.build`).
+
+use std::collections::{BTreeSet, HashMap};
+
+use polars::prelude::*;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3_polars::PyDataFrame;
+
+use crate::to_py;
+
+/// Linear-interpolation percentile over an already-sorted slice (matches
+/// numpy's default `interpolation="linear"`, which is what sklearn's
+/// `RobustScaler` uses internally).
+fn percentile_linear(sorted: &[f64], q: f64) -> f64 {
+    let n = sorted.len();
+    if n == 1 {
+        return sorted[0];
+    }
+    let pos = q / 100.0 * (n as f64 - 1.0);
+    let lo = pos.floor() as usize;
+    let hi = pos.ceil() as usize;
+    let frac = pos - lo as f64;
+    if lo == hi {
+        sorted[lo]
+    } else {
+        sorted[lo] + frac * (sorted[hi] - sorted[lo])
+    }
+}
+
+/// Scale each column in place to match `sklearn.preprocessing.RobustScaler`
+/// (median-center, divide by IQR; an IQR of 0 leaves the column unscaled, per
+/// sklearn's documented behavior).
+fn robust_scale_columns(matrix: &mut [Vec<f64>], num_cols: usize) {
+    let num_rows = matrix.len();
+    for col in 0..num_cols {
+        let mut values: Vec<f64> = (0..num_rows).map(|row| matrix[row][col]).collect();
+        values.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let median = percentile_linear(&values, 50.0);
+        let q1 = percentile_linear(&values, 25.0);
+        let q3 = percentile_linear(&values, 75.0);
+        let iqr = q3 - q1;
+        let scale = if iqr == 0.0 { 1.0 } else { iqr };
+        for row in matrix.iter_mut() {
+            row[col] = (row[col] - median) / scale;
+        }
+    }
+}
+
+/// Bray-Curtis distance: `sum(|u_i - v_i|) / sum(|u_i + v_i|)`, replacing a
+/// NaN/infinite result (e.g. both vectors all-zero) with 1.0 (maximum
+/// distance), matching `np.nan_to_num(Y, nan=1.0, posinf=1.0, neginf=1.0)`.
+fn braycurtis(u: &[f64], v: &[f64]) -> f64 {
+    let mut num = 0.0;
+    let mut den = 0.0;
+    for (a, b) in u.iter().zip(v) {
+        num += (a - b).abs();
+        den += (a + b).abs();
+    }
+    let d = num / den;
+    if d.is_nan() || d.is_infinite() {
+        1.0
+    } else {
+        d
+    }
+}
+
+/// Build a cluster-by-cluster Bray-Curtis distance matrix (RobustScaler ->
+/// `pdist(braycurtis)`) from per-cluster taxon averages, as a condensed
+/// (upper-triangular, scipy `pdist`-order) distance vector plus the cluster
+/// IDs in row order.
+///
+/// Mirrors `ClusterDistanceMatrix.build` / `pivot_taxon_counts_for_clusters`.
+/// Row/column order need not match Python's `pivot()` order exactly — both
+/// RobustScaler (per-column) and Bray-Curtis (order-invariant sums) give
+/// identical distances under any consistent column permutation, and this
+/// function returns `cluster_ids` alongside the condensed vector precisely so
+/// callers can look distances up by cluster ID rather than raw position.
+#[pyfunction]
+pub fn build_cluster_distance_matrix(
+    cluster_taxa_stats_df: PyDataFrame,
+) -> PyResult<(Vec<f64>, Vec<u32>)> {
+    let df: DataFrame = cluster_taxa_stats_df.into();
+
+    let cluster_ca = df
+        .column("cluster")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .u32()
+        .map_err(to_py)?
+        .clone();
+    let taxon_ca = df
+        .column("taxonId")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .u32()
+        .map_err(to_py)?
+        .clone();
+    let average_ca = df
+        .column("average")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .f64()
+        .map_err(to_py)?
+        .clone();
+
+    let rows: Vec<(u32, u32, f64)> = cluster_ca
+        .iter()
+        .zip(taxon_ca.into_no_null_iter())
+        .zip(average_ca.into_no_null_iter())
+        .filter_map(|((cluster, taxon_id), average)| cluster.map(|c| (c, taxon_id, average)))
+        .collect();
+
+    let cluster_ids: Vec<u32> = rows
+        .iter()
+        .map(|&(c, _, _)| c)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    let taxon_ids: Vec<u32> = rows
+        .iter()
+        .map(|&(_, t, _)| t)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+
+    if cluster_ids.len() <= 1 {
+        return Err(PyValueError::new_err(
+            "More than one cluster is required to calculate distances",
+        ));
+    }
+
+    let cluster_index: HashMap<u32, usize> = cluster_ids
+        .iter()
+        .enumerate()
+        .map(|(i, &c)| (c, i))
+        .collect();
+    let taxon_index: HashMap<u32, usize> =
+        taxon_ids.iter().enumerate().map(|(i, &t)| (t, i)).collect();
+
+    let mut matrix = vec![vec![0.0f64; taxon_ids.len()]; cluster_ids.len()];
+    for (cluster, taxon_id, average) in rows {
+        matrix[cluster_index[&cluster]][taxon_index[&taxon_id]] = average;
+    }
+
+    robust_scale_columns(&mut matrix, taxon_ids.len());
+
+    let mut condensed = Vec::with_capacity(cluster_ids.len() * (cluster_ids.len() - 1) / 2);
+    for i in 0..cluster_ids.len() {
+        for j in (i + 1)..cluster_ids.len() {
+            condensed.push(braycurtis(&matrix[i], &matrix[j]));
+        }
+    }
+
+    Ok((condensed, cluster_ids))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn percentile_matches_numpy_linear() {
+        let sorted = [1.0, 2.0, 3.0, 4.0];
+        // numpy.percentile([1,2,3,4], 50) == 2.5
+        assert_eq!(percentile_linear(&sorted, 50.0), 2.5);
+        // numpy.percentile([1,2,3,4], 25) == 1.75
+        assert_eq!(percentile_linear(&sorted, 25.0), 1.75);
+    }
+
+    #[test]
+    fn braycurtis_matches_known_value() {
+        // scipy.spatial.distance.braycurtis([1,0,0],[0,1,0]) == 1.0
+        assert_eq!(braycurtis(&[1.0, 0.0, 0.0], &[0.0, 1.0, 0.0]), 1.0);
+        // identical vectors -> 0 distance
+        assert_eq!(braycurtis(&[1.0, 2.0, 3.0], &[1.0, 2.0, 3.0]), 0.0);
+    }
+
+    #[test]
+    fn braycurtis_all_zero_maps_to_max_distance() {
+        assert_eq!(braycurtis(&[0.0, 0.0], &[0.0, 0.0]), 1.0);
+    }
+}

--- a/bioregion_rs/src/matrices/mod.rs
+++ b/bioregion_rs/src/matrices/mod.rs
@@ -1,3 +1,4 @@
 //! Ports of `src/matrices/*.py`.
 
+pub mod cluster_distance;
 pub mod geocode_connectivity;


### PR DESCRIPTION
## Summary
- Ports `src/matrices/cluster_distance.py::ClusterDistanceMatrix.build` to Rust (`build_cluster_distance_matrix` in `bioregion_rs`).
- Unlike `geocode_distance.py` (Phase 3), this file has **no UMAP step** — it's just `RobustScaler` (median/IQR per column) then `pdist(metric="braycurtis")`, both fully portable, so this is a complete port rather than scaffolding for later.
- `RobustScaler` is hand-ported: numpy's linear-interpolation percentile algorithm, and sklearn's documented behavior of leaving a column unscaled when its IQR is 0.
- Returns a condensed (scipy `pdist`-order) distance vector plus the cluster IDs in row order, rather than a `ClusterDistanceMatrix` object — row/column order doesn't need to match Python's `pivot()` exactly, since both RobustScaler (per-column) and Bray-Curtis (order-invariant sums) give identical distances under any *consistent* column permutation.
- Verified against `ClusterDistanceMatrix.build` in `harness.py` by looking up pairwise distances by cluster-ID pair (order-independent).
- **Caveat found while testing, documented in the plan:** with exactly 2 clusters, `RobustScaler` always scales every non-constant column to a perfect ±1 pair, making Bray-Curtis's `sum(|u+v|)` denominator ~0 for every such column — the distance becomes a huge, floating-point-rounding-dominated number that two independent implementations have no reason to agree on bit-for-bit. This is a property of the algorithm at k=2, not a port bug; the harness test uses more clusters to avoid it, but real runs with `min_clusters=2` could hit this instability in Python today too.

## Test plan
- [x] `cargo test --lib` (10 tests pass)
- [x] `uv run maturin develop --manifest-path bioregion_rs/Cargo.toml`
- [x] `uv run python bioregion_rs/harness.py` (all checks pass, including the new `build_cluster_distance_matrix` check)
- [x] `uv run pyright` (0 errors)
- [x] bioregion_rs CI job will run on this PR's push

https://claude.ai/code/session_01XefuZ41iibHEgQrxWiqDjg