### PR TITLE
Phase 2: port cluster_color.py (geographic path) to Rust

### DIFF
--- a/RUST_MIGRATION_PLAN.md
+++ b/RUST_MIGRATION_PLAN.md
@@ -287,9 +287,19 @@ validated).
   property of the algorithm at k=2, not a port bug; the harness test uses more clusters
   to avoid it, but real runs with `min_clusters=2` could hit this instability in Python
   today too.
-- `src/dataframes/cluster_color.py` **(geographic path only)** — `nx.greedy_color` →
-  `petgraph`'s greedy coloring; palette mapping is deterministic. ✅
-  (Taxonomic path uses UMAP+MDS — see Phase 3.)
+- `src/dataframes/cluster_color.py` **(geographic path only)** — ✅ DONE:
+  `build_cluster_color`. No `petgraph` needed — greedy coloring (`largest_first`
+  ordering: nodes sorted by degree descending, stable-sorted so ties keep original
+  order, then each node gets the smallest color index not used by an already-colored
+  neighbor) is a ~20-line hand-rolled algorithm, exactly matching
+  `networkx.coloring.greedy_color(G, strategy="largest_first")`. The palette step
+  (`sns.color_palette("YlOrRd", n)`) turned out to be fully portable too: reverse-
+  engineered matplotlib's exact sampling algorithm (`LinearSegmentedColormap`'s 9
+  control points per RGB channel, piecewise-linear interpolation, `floor(x*256)`
+  index quantization; seaborn samples at `linspace(0,1,n+2)[1:-1]`, excluding the
+  colormap's extremes) and verified it reproduces `sns.color_palette("YlOrRd",
+  n).as_hex()` bit-for-bit for n up to 15. `darken_hex_color` (Phase 0) is reused
+  directly. (Taxonomic path uses UMAP+MDS — see Phase 3.)
 - `src/dataframes/cluster_boundary.py` — union hex boundary polygons per cluster.
   `geo`'s `unary_union` / boolean ops (or `geos` bindings for robustness). moderate
 - `src/dataframes/cluster_significant_differences.py` — 2×2 Fisher's exact per (cluster,

--- a/bioregion_rs/README.md
+++ b/bioregion_rs/README.md
@@ -20,6 +20,8 @@ every subsequent file migration will use.
   - `build_cluster_taxa_statistics` — mirrors `src/dataframes/cluster_taxa_statistics.py`.
   - `build_cluster_neighbors` — mirrors `src/dataframes/cluster_neighbors.py`.
   - `build_cluster_distance_matrix` — mirrors `src/matrices/cluster_distance.py`.
+  - `build_cluster_color` — mirrors `src/dataframes/cluster_color.py` (geographic
+    path only; the taxonomic path uses UMAP + MDS and stays in Python).
 - `harness.py` — runs each Rust function and its Python counterpart on the same
   input and asserts they match. The template for migrating each file.
 

--- a/bioregion_rs/harness.py
+++ b/bioregion_rs/harness.py
@@ -22,6 +22,7 @@ from scipy.spatial.distance import squareform
 
 import bioregion_rs
 from src.colors import darken_hex_color as py_darken
+from src.dataframes.cluster_color import build_cluster_color_df
 from src.dataframes.cluster_neighbors import build_cluster_neighbors_df
 from src.dataframes.cluster_taxa_statistics import build_cluster_taxa_statistics_df
 from src.dataframes.darwin_core import build_darwin_core_lf
@@ -478,6 +479,44 @@ def test_build_cluster_distance_matrix() -> None:
     )
 
 
+# --- src/dataframes/cluster_color.py (geographic path only) ------------------
+
+
+def test_build_cluster_color() -> None:
+    print("src/dataframes/cluster_color.py  (build_cluster_color, geographic):")
+    bbox, precision, _darwin_lf, darwin_df, geocode_no_edges_df = (
+        _load_bbox_darwin_and_geocode_no_edges()
+    )
+    geocode_df = build_geocode_df(darwin_df.lazy(), precision, bbox)
+    py_neighbors = build_geocode_neighbors_df(geocode_df)
+    py_neighbors_no_edges = build_geocode_neighbors_no_edges_df(
+        py_neighbors, geocode_no_edges_df
+    )
+
+    # Cluster by row index (not geocode value): see the note in
+    # test_build_cluster_neighbors. Use enough clusters that the adjacency
+    # graph actually needs more than one color.
+    geocodes = py_neighbors_no_edges["geocode"].sort()
+    geocode_cluster_df = pl.DataFrame(
+        {"geocode": geocodes, "cluster": [i % 4 for i in range(len(geocodes))]}
+    ).cast({"geocode": pl.UInt64, "cluster": pl.UInt32})
+    cluster_neighbors_df = build_cluster_neighbors_df(
+        py_neighbors_no_edges, geocode_cluster_df
+    )
+
+    rust_out = bioregion_rs.build_cluster_color(cluster_neighbors_df)
+    py_out = build_cluster_color_df(
+        cluster_neighbors_df.lazy(), color_method="geographic"
+    )
+
+    check(f"non-trivial: {py_out.height} clusters colored", py_out.height > 1)
+
+    def _rows(df: pl.DataFrame) -> set:
+        return set(df.select("cluster", "color", "darkened_color").iter_rows())
+
+    check("same (cluster, color, darkened_color) row set", _rows(rust_out) == _rows(py_out))
+
+
 # --- parquet stage boundary --------------------------------------------------
 
 
@@ -508,6 +547,7 @@ def main() -> None:
     test_build_cluster_taxa_statistics()
     test_build_cluster_neighbors()
     test_build_cluster_distance_matrix()
+    test_build_cluster_color()
     test_parquet_boundary()
     print("\nAll interop + correctness checks passed.")
 

--- a/bioregion_rs/src/dataframes/cluster_color.rs
+++ b/bioregion_rs/src/dataframes/cluster_color.rs
@@ -1,0 +1,200 @@
+//! Port of `src/dataframes/cluster_color.py` — **geographic path only**
+//! (`_build_geographic`). The taxonomic path uses UMAP + MDS and stays in
+//! Python (Phase 3).
+
+use std::collections::{HashMap, HashSet};
+
+use polars::prelude::*;
+use pyo3::prelude::*;
+use pyo3_polars::PyDataFrame;
+
+use crate::colors::darken_hex_color;
+use crate::to_py;
+
+/// Control points (x, y) for matplotlib's `YlOrRd` colormap channels, copied
+/// from `matplotlib.colormaps['YlOrRd']._segmentdata` (a `LinearSegmentedColormap`
+/// with no discontinuities, so y0 == y1 at every stop).
+const YLORRD_RED: [(f64, f64); 9] = [
+    (0.0, 1.0),
+    (0.125, 1.0),
+    (0.25, 0.996078431372549),
+    (0.375, 0.996078431372549),
+    (0.5, 0.9921568627450981),
+    (0.625, 0.9882352941176471),
+    (0.75, 0.8901960784313725),
+    (0.875, 0.7411764705882353),
+    (1.0, 0.5019607843137255),
+];
+const YLORRD_GREEN: [(f64, f64); 9] = [
+    (0.0, 1.0),
+    (0.125, 0.9294117647058824),
+    (0.25, 0.8509803921568627),
+    (0.375, 0.6980392156862745),
+    (0.5, 0.5529411764705883),
+    (0.625, 0.3058823529411765),
+    (0.75, 0.10196078431372549),
+    (0.875, 0.0),
+    (1.0, 0.0),
+];
+const YLORRD_BLUE: [(f64, f64); 9] = [
+    (0.0, 0.8),
+    (0.125, 0.6274509803921569),
+    (0.25, 0.4627450980392157),
+    (0.375, 0.2980392156862745),
+    (0.5, 0.23529411764705882),
+    (0.625, 0.16470588235294117),
+    (0.75, 0.10980392156862745),
+    (0.875, 0.14901960784313725),
+    (1.0, 0.14901960784313725),
+];
+
+/// Piecewise-linear interpolation over a sorted set of (x, y) control points.
+fn interp(points: &[(f64, f64)], t: f64) -> f64 {
+    for w in points.windows(2) {
+        let (x0, y0) = w[0];
+        let (x1, y1) = w[1];
+        if t <= x1 {
+            let frac = if x1 > x0 { (t - x0) / (x1 - x0) } else { 0.0 };
+            return y0 + frac * (y1 - y0);
+        }
+    }
+    points.last().unwrap().1
+}
+
+/// Replicates `sns.color_palette("YlOrRd", n).as_hex()`: matplotlib samples a
+/// `LinearSegmentedColormap` by building a 256-entry lookup table (linear
+/// interpolation of the control points at 256 evenly spaced positions) and
+/// then indexing it with `floor(x * 256)`; seaborn picks the `n` sample
+/// positions as `linspace(0, 1, n + 2)[1:-1]` (excluding the extremes "to
+/// provide better contrast"). Verified bit-for-bit against
+/// `sns.color_palette("YlOrRd", n).as_hex()` for n up to 15 while porting.
+fn ylorrd_hex_palette(n: usize) -> Vec<String> {
+    (0..n)
+        .map(|i| {
+            let x = (i as f64 + 1.0) / (n as f64 + 1.0);
+            let idx = ((x * 256.0).floor() as usize).min(255);
+            let t = idx as f64 / 255.0;
+            let to_u8 = |v: f64| (v * 255.0).round() as u8;
+            format!(
+                "#{:02x}{:02x}{:02x}",
+                to_u8(interp(&YLORRD_RED, t)),
+                to_u8(interp(&YLORRD_GREEN, t)),
+                to_u8(interp(&YLORRD_BLUE, t)),
+            )
+        })
+        .collect()
+}
+
+/// Greedy graph coloring with the `largest_first` node ordering (nodes sorted
+/// by degree descending, ties broken by original order — a stable sort, same
+/// as Python's `sorted(G, key=G.degree, reverse=True)`), assigning each node
+/// the smallest color index not already used by a colored neighbor. Mirrors
+/// `networkx.coloring.greedy_color(G, strategy="largest_first")`.
+fn greedy_color(cluster_ids: &[u32], adjacency: &HashMap<u32, HashSet<u32>>) -> HashMap<u32, u32> {
+    let mut order = cluster_ids.to_vec();
+    order.sort_by_key(|c| std::cmp::Reverse(adjacency.get(c).map_or(0, HashSet::len)));
+
+    let mut colors: HashMap<u32, u32> = HashMap::new();
+    for node in order {
+        let neighbor_colors: HashSet<u32> = adjacency
+            .get(&node)
+            .into_iter()
+            .flatten()
+            .filter_map(|n| colors.get(n).copied())
+            .collect();
+        let mut color = 0;
+        while neighbor_colors.contains(&color) {
+            color += 1;
+        }
+        colors.insert(node, color);
+    }
+    colors
+}
+
+/// Build a ClusterColorSchema DataFrame using geographic neighbor-based
+/// coloring: greedy-color the cluster adjacency graph so neighboring
+/// clusters get different colors, then map color classes to a `YlOrRd` hex
+/// palette (fewest colors needed, in class order).
+///
+/// Mirrors `build_cluster_color_df(..., color_method="geographic")` /
+/// `_build_geographic`.
+#[pyfunction]
+pub fn build_cluster_color(cluster_neighbors_df: PyDataFrame) -> PyResult<PyDataFrame> {
+    let df: DataFrame = cluster_neighbors_df.into();
+
+    let cluster_ca = df
+        .column("cluster")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .u32()
+        .map_err(to_py)?
+        .clone();
+    let neighbors_ca = df
+        .column("direct_and_indirect_neighbors")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .list()
+        .map_err(to_py)?
+        .clone();
+
+    let cluster_ids: Vec<u32> = cluster_ca.into_no_null_iter().collect();
+    let mut adjacency: HashMap<u32, HashSet<u32>> = HashMap::new();
+    for (i, &cluster) in cluster_ids.iter().enumerate() {
+        let neighbors: HashSet<u32> = match neighbors_ca.get_as_series(i) {
+            Some(s) => s.u32().map_err(to_py)?.into_no_null_iter().collect(),
+            None => HashSet::new(),
+        };
+        adjacency.insert(cluster, neighbors);
+    }
+
+    let color_indices = greedy_color(&cluster_ids, &adjacency);
+    let num_colors = color_indices.values().collect::<HashSet<_>>().len();
+    let palette = ylorrd_hex_palette(num_colors);
+
+    let mut colors: Vec<String> = Vec::with_capacity(cluster_ids.len());
+    let mut darkened: Vec<String> = Vec::with_capacity(cluster_ids.len());
+    for &cluster in &cluster_ids {
+        let color = palette[color_indices[&cluster] as usize].clone();
+        darkened.push(darken_hex_color(&color, 0.5)?);
+        colors.push(color);
+    }
+
+    let out = DataFrame::new(
+        cluster_ids.len(),
+        vec![
+            UInt32Chunked::from_vec("cluster".into(), cluster_ids).into_column(),
+            StringChunked::from_iter_values("color".into(), colors.into_iter()).into_column(),
+            StringChunked::from_iter_values("darkened_color".into(), darkened.into_iter())
+                .into_column(),
+        ],
+    )
+    .map_err(to_py)?;
+
+    Ok(PyDataFrame(out))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ylorrd_matches_known_hex_values() {
+        // Verified against `sns.color_palette("YlOrRd", n).as_hex()`.
+        assert_eq!(ylorrd_hex_palette(2), vec!["#febf5a", "#f43d25"]);
+        assert_eq!(ylorrd_hex_palette(3), vec!["#fed976", "#fd8c3c", "#e2191c"]);
+    }
+
+    #[test]
+    fn greedy_color_avoids_adjacent_same_color() {
+        // Triangle: every node needs a distinct color.
+        let ids = vec![0, 1, 2];
+        let mut adjacency = HashMap::new();
+        adjacency.insert(0, HashSet::from([1, 2]));
+        adjacency.insert(1, HashSet::from([0, 2]));
+        adjacency.insert(2, HashSet::from([0, 1]));
+        let colors = greedy_color(&ids, &adjacency);
+        assert_ne!(colors[&0], colors[&1]);
+        assert_ne!(colors[&1], colors[&2]);
+        assert_ne!(colors[&0], colors[&2]);
+    }
+}

--- a/bioregion_rs/src/dataframes/mod.rs
+++ b/bioregion_rs/src/dataframes/mod.rs
@@ -1,5 +1,6 @@
 //! Ports of `src/dataframes/*.py`.
 
+pub mod cluster_color;
 pub mod cluster_neighbors;
 pub mod cluster_taxa_statistics;
 pub mod geocode;

--- a/bioregion_rs/src/lib.rs
+++ b/bioregion_rs/src/lib.rs
@@ -57,5 +57,9 @@ fn bioregion_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
         matrices::cluster_distance::build_cluster_distance_matrix,
         m
     )?)?;
+    m.add_function(wrap_pyfunction!(
+        dataframes::cluster_color::build_cluster_color,
+        m
+    )?)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Ports `src/dataframes/cluster_color.py`'s geographic path (`_build_geographic`) to Rust (`build_cluster_color` in `bioregion_rs`). The taxonomic path (UMAP + MDS) stays in Python — Phase 3.
- **Greedy graph coloring**: hand-rolled `largest_first` strategy (nodes sorted by degree descending, stable sort so ties keep original order, then each node gets the smallest color index not used by an already-colored neighbor). No `petgraph` needed — this is a ~20-line algorithm. Matches `networkx.coloring.greedy_color(G, strategy="largest_first")` exactly.
- **Palette generation**: the plan flagged `sns.color_palette("YlOrRd", n)` as "deterministic" but this PR actually verifies and ports it. Reverse-engineered matplotlib's `LinearSegmentedColormap` sampling algorithm (`YlOrRd`'s 9 RGB control points, piecewise-linear interpolation, `floor(x*256)` lookup-table indexing) and seaborn's sample positions (`linspace(0,1,n+2)[1:-1]`, excluding the colormap's extremes). Verified this reproduces `sns.color_palette("YlOrRd", n).as_hex()` bit-for-bit for n up to 15 while developing it.
- Reuses `darken_hex_color` from Phase 0 directly (in-crate function call, not a Python round-trip).
- Verified against `build_cluster_color_df(..., color_method="geographic")` in `harness.py` by comparing `(cluster, color, darkened_color)` as a row set.

## Test plan
- [x] `cargo test --lib` (12 tests pass, including exact `YlOrRd` hex-value checks)
- [x] `uv run maturin develop --manifest-path bioregion_rs/Cargo.toml`
- [x] `uv run python bioregion_rs/harness.py` (all checks pass, including the new `build_cluster_color` check)
- [x] `uv run pyright` (0 errors)
- [x] bioregion_rs CI job will run on this PR's push

https://claude.ai/code/session_01XefuZ41iibHEgQrxWiqDjg