### PR TITLE
Phase 2: port cluster_boundary.py to Rust

### DIFF
--- a/RUST_MIGRATION_PLAN.md
+++ b/RUST_MIGRATION_PLAN.md
@@ -300,8 +300,24 @@ validated).
   colormap's extremes) and verified it reproduces `sns.color_palette("YlOrRd",
   n).as_hex()` bit-for-bit for n up to 15. `darken_hex_color` (Phase 0) is reused
   directly. (Taxonomic path uses UMAP+MDS — see Phase 3.)
-- `src/dataframes/cluster_boundary.py` — union hex boundary polygons per cluster.
-  `geo`'s `unary_union` / boolean ops (or `geos` bindings for robustness). moderate
+- `src/dataframes/cluster_boundary.py` — ✅ DONE: `build_cluster_boundary`, using
+  `geo::unary_union` (no `geos` bindings needed) over WKB-decoded hexagon boundaries.
+  Added general WKB Polygon/MultiPolygon decode+encode to `wkb.rs` (rings + holes,
+  not just the single-ring hexagons `dataframes/geocode.rs` produces) to round-trip
+  through `geo::Polygon`/`MultiPolygon`. A single-geocode cluster is encoded as a bare
+  `Polygon` (matching Python exactly); a multi-geocode cluster is always encoded as a
+  `MultiPolygon` (`unary_union`'s return type), even when the pieces fully merge into
+  one shape — unlike shapely, which collapses that case to a bare `Polygon`. This is a
+  WKB type-tag difference only, not a shape difference (GEOS treats a one-polygon
+  `MultiPolygon` as topologically `.equals()` the bare `Polygon`, confirmed while
+  testing). **Geometry-robustness caveat found while verifying:** `geo`'s
+  `i_overlay`-based union and GEOS's union are different implementations, so the
+  unioned shapes differ by a tiny amount (~2e-7 relative, i.e. floating-point-level
+  vertex differences at shared hexagon edges) — the harness compares with a relative
+  symmetric-difference tolerance instead of exact equality, unlike the exact/bit-for-bit
+  checks used everywhere else in this crate. This is the exact "geometry robustness"
+  risk this plan flagged at the top; in practice `geo` was accurate enough that `geos`
+  bindings weren't needed.
 - `src/dataframes/cluster_significant_differences.py` — 2×2 Fisher's exact per (cluster,
   taxon) + log2 fold change + normalized scoring. Port `fisher_exact` (hypergeometric tail
   sum; use `statrs`). The scoring math is plain polars. moderate

--- a/bioregion_rs/README.md
+++ b/bioregion_rs/README.md
@@ -22,6 +22,7 @@ every subsequent file migration will use.
   - `build_cluster_distance_matrix` — mirrors `src/matrices/cluster_distance.py`.
   - `build_cluster_color` — mirrors `src/dataframes/cluster_color.py` (geographic
     path only; the taxonomic path uses UMAP + MDS and stays in Python).
+  - `build_cluster_boundary` — mirrors `src/dataframes/cluster_boundary.py`.
 - `harness.py` — runs each Rust function and its Python counterpart on the same
   input and asserts they match. The template for migrating each file.
 

--- a/bioregion_rs/harness.py
+++ b/bioregion_rs/harness.py
@@ -22,6 +22,7 @@ from scipy.spatial.distance import squareform
 
 import bioregion_rs
 from src.colors import darken_hex_color as py_darken
+from src.dataframes.cluster_boundary import build_cluster_boundary_df
 from src.dataframes.cluster_color import build_cluster_color_df
 from src.dataframes.cluster_neighbors import build_cluster_neighbors_df
 from src.dataframes.cluster_taxa_statistics import build_cluster_taxa_statistics_df
@@ -517,6 +518,52 @@ def test_build_cluster_color() -> None:
     check("same (cluster, color, darkened_color) row set", _rows(rust_out) == _rows(py_out))
 
 
+# --- src/dataframes/cluster_boundary.py ---------------------------------------
+
+
+def test_build_cluster_boundary() -> None:
+    print("src/dataframes/cluster_boundary.py  (build_cluster_boundary):")
+    _bbox, _precision, _darwin_lf, _darwin_df, geocode_no_edges_df = (
+        _load_bbox_darwin_and_geocode_no_edges()
+    )
+
+    # Cluster by row index (not geocode value): see the note in
+    # test_build_cluster_neighbors.
+    geocodes = geocode_no_edges_df["geocode"].sort()
+    geocode_cluster_df = pl.DataFrame(
+        {"geocode": geocodes, "cluster": [i % 3 for i in range(len(geocodes))]}
+    ).cast({"geocode": pl.UInt64, "cluster": pl.UInt32})
+
+    rust_out = bioregion_rs.build_cluster_boundary(geocode_cluster_df, geocode_no_edges_df)
+    py_out = build_cluster_boundary_df(geocode_cluster_df, geocode_no_edges_df.lazy())
+
+    check(f"non-trivial: {py_out.height} cluster boundaries", py_out.height > 1)
+    check(
+        "same cluster set",
+        set(rust_out["cluster"].to_list()) == set(py_out["cluster"].to_list()),
+    )
+
+    # Relative (not absolute) tolerance: geo's i_overlay-based unary_union and
+    # GEOS's union algorithm are different implementations, so tiny
+    # floating-point differences in how they resolve shared hexagon edges are
+    # expected (unlike the direct WKB pass-through checks elsewhere in this
+    # harness) — this is the "geometry robustness" caveat the migration plan
+    # already flagged, not a correctness bug.
+    rust_geoms = dict(rust_out.select("cluster", "geometry").iter_rows())
+    py_geoms = dict(py_out.select("cluster", "geometry").iter_rows())
+    max_relative_symdiff = max(
+        shapely.from_wkb(rust_geoms[cluster])
+        .symmetric_difference(shapely.from_wkb(py_geoms[cluster]))
+        .area
+        / shapely.from_wkb(py_geoms[cluster]).area
+        for cluster in rust_geoms
+    )
+    check(
+        f"geometries match (max relative sym-diff {max_relative_symdiff:.2e})",
+        max_relative_symdiff < 1e-5,
+    )
+
+
 # --- parquet stage boundary --------------------------------------------------
 
 
@@ -548,6 +595,7 @@ def main() -> None:
     test_build_cluster_neighbors()
     test_build_cluster_distance_matrix()
     test_build_cluster_color()
+    test_build_cluster_boundary()
     test_parquet_boundary()
     print("\nAll interop + correctness checks passed.")
 

--- a/bioregion_rs/src/dataframes/cluster_boundary.rs
+++ b/bioregion_rs/src/dataframes/cluster_boundary.rs
@@ -1,0 +1,114 @@
+//! Port of `src/dataframes/cluster_boundary.py` (`build_cluster_boundary_df`).
+
+use std::collections::{BTreeMap, HashMap};
+
+use geo::{Polygon, unary_union};
+use polars::prelude::*;
+use pyo3::prelude::*;
+use pyo3_polars::PyDataFrame;
+
+use crate::{to_py, wkb};
+
+/// Build a ClusterBoundarySchema DataFrame: a single boundary geometry per
+/// cluster, formed by unioning all its geocodes' hexagon boundaries.
+///
+/// Mirrors `build_cluster_boundary_df`. Clusters are emitted in ascending
+/// order (matching `iter_clusters_and_geocodes`'s `.sort("cluster")`). A
+/// single-geocode cluster is encoded as a bare `Polygon`, matching Python
+/// (which keeps `cluster_geocode_boundaries[0]` as-is); a multi-geocode
+/// cluster is encoded as a `MultiPolygon` (`geo::unary_union`'s return type),
+/// even when the pieces fully merge into one connected shape — unlike
+/// shapely, which would collapse that case to a bare `Polygon`. This
+/// doesn't change the geometry's actual shape (shapely and GEOS both treat a
+/// one-polygon `MultiPolygon` as topologically equal to that `Polygon`), only
+/// its WKB type tag.
+#[pyfunction]
+pub fn build_cluster_boundary(
+    geocode_cluster_df: PyDataFrame,
+    geocode_df: PyDataFrame,
+) -> PyResult<PyDataFrame> {
+    let geocode_cluster_df: DataFrame = geocode_cluster_df.into();
+    let geocode_df: DataFrame = geocode_df.into();
+
+    let geocode_to_boundary: HashMap<u64, Polygon<f64>> = {
+        let geocode = geocode_df
+            .column("geocode")
+            .map_err(to_py)?
+            .as_materialized_series()
+            .u64()
+            .map_err(to_py)?
+            .clone();
+        let boundary = geocode_df
+            .column("boundary")
+            .map_err(to_py)?
+            .as_materialized_series()
+            .binary()
+            .map_err(to_py)?
+            .clone();
+        geocode
+            .into_no_null_iter()
+            .zip(boundary.iter())
+            .map(|(g, b)| {
+                (
+                    g,
+                    wkb::decode_polygon(b.expect("boundary column must be non-null")),
+                )
+            })
+            .collect()
+    };
+
+    let cluster_ca = geocode_cluster_df
+        .column("cluster")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .u32()
+        .map_err(to_py)?
+        .clone();
+    let geocode_ca = geocode_cluster_df
+        .column("geocode")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .u64()
+        .map_err(to_py)?
+        .clone();
+
+    let mut cluster_boundaries: BTreeMap<u32, Vec<Polygon<f64>>> = BTreeMap::new();
+    for (cluster, geocode) in cluster_ca
+        .into_no_null_iter()
+        .zip(geocode_ca.into_no_null_iter())
+    {
+        if let Some(boundary) = geocode_to_boundary.get(&geocode) {
+            cluster_boundaries
+                .entry(cluster)
+                .or_default()
+                .push(boundary.clone());
+        }
+    }
+
+    let mut clusters: Vec<u32> = Vec::new();
+    let mut geometries: Vec<Vec<u8>> = Vec::new();
+    for (cluster, boundaries) in cluster_boundaries {
+        if boundaries.is_empty() {
+            continue;
+        }
+        let wkb_bytes = if boundaries.len() == 1 {
+            wkb::encode_polygon(&boundaries[0])
+        } else {
+            wkb::encode_multi_polygon(&unary_union(&boundaries))
+        };
+        clusters.push(cluster);
+        geometries.push(wkb_bytes);
+    }
+
+    let geometry_ca: BinaryChunked = geometries.iter().map(|v| Some(v.as_slice())).collect();
+    let out = DataFrame::new(
+        clusters.len(),
+        vec![
+            UInt32Chunked::from_vec("cluster".into(), clusters).into_column(),
+            geometry_ca.with_name("geometry".into()).into_column(),
+        ],
+    )
+    .map_err(to_py)?;
+
+    Ok(PyDataFrame(out))
+}

--- a/bioregion_rs/src/dataframes/mod.rs
+++ b/bioregion_rs/src/dataframes/mod.rs
@@ -1,5 +1,6 @@
 //! Ports of `src/dataframes/*.py`.
 
+pub mod cluster_boundary;
 pub mod cluster_color;
 pub mod cluster_neighbors;
 pub mod cluster_taxa_statistics;

--- a/bioregion_rs/src/lib.rs
+++ b/bioregion_rs/src/lib.rs
@@ -61,5 +61,9 @@ fn bioregion_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
         dataframes::cluster_color::build_cluster_color,
         m
     )?)?;
+    m.add_function(wrap_pyfunction!(
+        dataframes::cluster_boundary::build_cluster_boundary,
+        m
+    )?)?;
     Ok(())
 }

--- a/bioregion_rs/src/wkb.rs
+++ b/bioregion_rs/src/wkb.rs
@@ -1,11 +1,15 @@
-//! Minimal little-endian WKB encoders for the geometry types the pipeline emits.
+//! Minimal little-endian WKB encoders/decoders for the geometry types the
+//! pipeline emits.
 //!
 //! Standard ISO WKB (no SRID), which `shapely.from_wkb` and `polars-st` both read.
 //! Coordinates are written in (x = longitude, y = latitude) order.
 
+use geo::{Coord, LineString, MultiPolygon, Polygon};
+
 const BYTE_ORDER_LE: u8 = 1;
 const TYPE_POINT: u32 = 1;
 const TYPE_POLYGON: u32 = 3;
+const TYPE_MULTIPOLYGON: u32 = 6;
 
 /// Encode a 2D point as WKB.
 pub fn point(x: f64, y: f64) -> Vec<u8> {
@@ -46,6 +50,69 @@ pub fn decode_point(bytes: &[u8]) -> (f64, f64) {
     (x, y)
 }
 
+/// Decode a WKB Polygon (any number of rings: exterior + holes) into a
+/// `geo::Polygon`. Panics on malformed input or an unexpected geometry type.
+pub fn decode_polygon(bytes: &[u8]) -> Polygon<f64> {
+    assert_eq!(
+        bytes[0], BYTE_ORDER_LE,
+        "only little-endian WKB is supported"
+    );
+    let kind = u32::from_le_bytes(bytes[1..5].try_into().unwrap());
+    assert_eq!(kind, TYPE_POLYGON, "expected a WKB Polygon");
+    let num_rings = u32::from_le_bytes(bytes[5..9].try_into().unwrap()) as usize;
+    let mut offset = 9;
+    let mut rings: Vec<LineString<f64>> = Vec::with_capacity(num_rings);
+    for _ in 0..num_rings {
+        let num_points = u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap()) as usize;
+        offset += 4;
+        let mut coords: Vec<Coord<f64>> = Vec::with_capacity(num_points);
+        for _ in 0..num_points {
+            let x = f64::from_le_bytes(bytes[offset..offset + 8].try_into().unwrap());
+            let y = f64::from_le_bytes(bytes[offset + 8..offset + 16].try_into().unwrap());
+            coords.push(Coord { x, y });
+            offset += 16;
+        }
+        rings.push(LineString::new(coords));
+    }
+    let exterior = rings.remove(0);
+    Polygon::new(exterior, rings)
+}
+
+/// Encode a `geo::Polygon` (exterior + any holes) as WKB.
+pub fn encode_polygon(poly: &Polygon<f64>) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.push(BYTE_ORDER_LE);
+    buf.extend_from_slice(&TYPE_POLYGON.to_le_bytes());
+    let interiors = poly.interiors();
+    buf.extend_from_slice(&(1 + interiors.len() as u32).to_le_bytes());
+    encode_ring(&mut buf, poly.exterior());
+    for ring in interiors {
+        encode_ring(&mut buf, ring);
+    }
+    buf
+}
+
+fn encode_ring(buf: &mut Vec<u8>, ring: &LineString<f64>) {
+    buf.extend_from_slice(&(ring.0.len() as u32).to_le_bytes());
+    for coord in &ring.0 {
+        buf.extend_from_slice(&coord.x.to_le_bytes());
+        buf.extend_from_slice(&coord.y.to_le_bytes());
+    }
+}
+
+/// Encode a `geo::MultiPolygon` as WKB (each element is itself a full WKB
+/// Polygon buffer, per the WKB MultiPolygon spec).
+pub fn encode_multi_polygon(mp: &MultiPolygon<f64>) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.push(BYTE_ORDER_LE);
+    buf.extend_from_slice(&TYPE_MULTIPOLYGON.to_le_bytes());
+    buf.extend_from_slice(&(mp.0.len() as u32).to_le_bytes());
+    for poly in &mp.0 {
+        buf.extend_from_slice(&encode_polygon(poly));
+    }
+    buf
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -72,5 +139,17 @@ mod tests {
         );
         assert_eq!(u32::from_le_bytes(b[5..9].try_into().unwrap()), 1);
         assert_eq!(u32::from_le_bytes(b[9..13].try_into().unwrap()), 4);
+    }
+
+    #[test]
+    fn decode_polygon_round_trips_through_encode() {
+        let ring = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 0.0)];
+        let decoded = decode_polygon(&polygon(&ring));
+        assert_eq!(decoded.interiors().len(), 0);
+        let coords: Vec<(f64, f64)> = decoded.exterior().coords().map(|c| (c.x, c.y)).collect();
+        assert_eq!(coords, ring);
+
+        let re_encoded = encode_polygon(&decoded);
+        assert_eq!(decode_polygon(&re_encoded).exterior(), decoded.exterior());
     }
 }


### PR DESCRIPTION
## Summary
- Ports `src/dataframes/cluster_boundary.py::build_cluster_boundary_df` to Rust (`build_cluster_boundary` in `bioregion_rs`).
- Unions each cluster's hexagon boundaries into a single geometry via `geo::unary_union` — no `geos` bindings needed, `geo`'s pure-Rust boolean ops turned out accurate enough.
- Extends `wkb.rs` with general Polygon/MultiPolygon decode+encode (arbitrary rings + holes), beyond the single-ring hexagon-only encoding `dataframes/geocode.rs` already had, so results can round-trip through `geo::Polygon`/`MultiPolygon`.
- A single-geocode cluster is encoded as a bare `Polygon` (matching Python exactly); a multi-geocode cluster is always a `MultiPolygon` (`unary_union`'s return type), even when the pieces fully merge into one shape — unlike shapely, which collapses that case to a bare `Polygon`. Confirmed this is a WKB type-tag difference only, not a shape difference (GEOS treats a one-polygon `MultiPolygon` as topologically `.equals()` the bare `Polygon`).
- **Geometry-robustness caveat found while verifying, documented in the plan:** `geo`'s `i_overlay`-based union and GEOS's union are different implementations, so the unioned shapes differ by a tiny amount (~2e-7 relative area — floating-point-level vertex differences at shared hexagon edges). The harness compares with a relative symmetric-difference tolerance instead of exact equality, unlike the exact/bit-for-bit checks used everywhere else in this crate. This is exactly the "geometry robustness" risk the migration plan flagged up front.

## Test plan
- [x] `cargo test --lib` (13 tests pass)
- [x] `uv run maturin develop --manifest-path bioregion_rs/Cargo.toml`
- [x] `uv run python bioregion_rs/harness.py` (all checks pass, including the new `build_cluster_boundary` check)
- [x] `uv run pyright` (0 errors)
- [x] bioregion_rs CI job will run on this PR's push

https://claude.ai/code/session_01XefuZ41iibHEgQrxWiqDjg