### PR TITLE
Phase 2: port geocode_silhouette_score.py to Rust

### DIFF
--- a/RUST_MIGRATION_PLAN.md
+++ b/RUST_MIGRATION_PLAN.md
@@ -384,10 +384,13 @@ validated).
   used everywhere else (Fisher's exact, `YlOrRd`, robust scaling, etc.). `get_elbow_analysis`/
   `get_metrics_summary`/`get_metric_interpretations` stay in Python (plotting/presentation
   helpers).
-- `src/dataframes/geocode_silhouette_score.py` — TODO: per-sample silhouette (needs
-  `silhouette_samples`, not just the mean `silhouette_score` this PR ported for
-  `geocode_cluster_metrics.py` — same underlying formula, extended to return one score
-  per point instead of the average).
+- `src/dataframes/geocode_silhouette_score.py` — ✅ DONE: `build_geocode_silhouette_score`.
+  Same per-point formula as `geocode_cluster_metrics.py`'s mean silhouette score (both
+  read from sklearn's `_silhouette_reduce`), extended to emit one score per geocode
+  instead of just the average — plus a leading `geocode = null` row per k holding that
+  average, matching the Python output shape exactly. Verified against
+  `build_geocode_silhouette_score_df` on the same hand-built multi-k fixture used for
+  `geocode_cluster_metrics.py`.
 - `src/cluster_optimization.py` — thin orchestration over metrics + elbow. ✅
 - `src/dataframes/significant_taxa_images.py` — image URL/id lookup join. ✅ (confirm no
   network fetch; if it hits an API, keep that thin bit in Python or use `reqwest`).

--- a/bioregion_rs/README.md
+++ b/bioregion_rs/README.md
@@ -34,6 +34,9 @@ every subsequent file migration will use.
     `src/dataframes/geocode_cluster_metrics.py`. Elbow detection uses the `kneed`
     crate rather than a hand-rolled Kneedle port — see the plan for why (a hand-rolled
     first pass had a real, if subtle, bug around curve-endpoint handling).
+  - `build_geocode_silhouette_score` — mirrors `src/dataframes/geocode_silhouette_score.py`
+    (per-point silhouette scores; same formula as `build_geocode_cluster_metrics`'s
+    mean, extended to per-geocode).
 - `harness.py` — runs each Rust function and its Python counterpart on the same
   input and asserts they match. The template for migrating each file.
 

--- a/bioregion_rs/harness.py
+++ b/bioregion_rs/harness.py
@@ -41,6 +41,7 @@ from src.dataframes.geocode_neighbors import (
     build_geocode_neighbors_no_edges_df,
     graph as neighbors_graph,
 )
+from src.dataframes.geocode_silhouette_score import build_geocode_silhouette_score_df
 from src.dataframes.geocode_taxa_counts import build_geocode_taxa_counts_lf
 from src.dataframes.permanova_results import build_permanova_results_df
 from src.dataframes.taxonomy import build_taxonomy_lf
@@ -709,12 +710,9 @@ def test_build_permanova_results() -> None:
 # --- src/dataframes/geocode_cluster_metrics.py --------------------------------
 
 
-def test_build_geocode_cluster_metrics() -> None:
-    print(
-        "src/dataframes/geocode_cluster_metrics.py  (build_geocode_cluster_metrics):"
-    )
-    # Hand-built (not sample-archive-derived): 6 points forming 3 tight pairs,
-    # each pair far from the others, tested at both k=2 and k=3.
+def _six_point_three_pair_fixture():
+    """Hand-built (not sample-archive-derived): 6 points forming 3 tight
+    pairs, each pair far from the others, tested at both k=2 and k=3."""
     geocode_ids = [1, 2, 3, 4, 5, 6]
     condensed = [
         0.1, 2.0, 2.0, 3.0, 3.0,  # (1,2) (1,3) (1,4) (1,5) (1,6)
@@ -732,6 +730,16 @@ def test_build_geocode_cluster_metrics() -> None:
     ).cast({"geocode": pl.UInt64, "cluster": pl.UInt32, "num_clusters": pl.UInt32})
     distance_matrix = GeocodeDistanceMatrix(
         condensed=np.array(condensed), reduced_features=np.empty((6, 0))
+    )
+    return condensed, geocode_cluster_multi_k_df, distance_matrix
+
+
+def test_build_geocode_cluster_metrics() -> None:
+    print(
+        "src/dataframes/geocode_cluster_metrics.py  (build_geocode_cluster_metrics):"
+    )
+    condensed, geocode_cluster_multi_k_df, distance_matrix = (
+        _six_point_three_pair_fixture()
     )
 
     rust_out = bioregion_rs.build_geocode_cluster_metrics(
@@ -770,6 +778,33 @@ def test_build_geocode_cluster_metrics() -> None:
     check(f"elbow k matches (rust={rust_k}, py={py_k})", rust_k == py_k)
 
 
+# --- src/dataframes/geocode_silhouette_score.py -------------------------------
+
+
+def test_build_geocode_silhouette_score() -> None:
+    print(
+        "src/dataframes/geocode_silhouette_score.py  (build_geocode_silhouette_score):"
+    )
+    condensed, geocode_cluster_multi_k_df, distance_matrix = (
+        _six_point_three_pair_fixture()
+    )
+
+    rust_out = bioregion_rs.build_geocode_silhouette_score(
+        condensed, geocode_cluster_multi_k_df
+    )
+    py_out = build_geocode_silhouette_score_df(distance_matrix, geocode_cluster_multi_k_df)
+
+    check(f"non-trivial: {py_out.height} rows", py_out.height == 2 * (6 + 1))
+
+    def _rows(df: pl.DataFrame) -> set:
+        return {
+            (row["geocode"], row["num_clusters"], round(row["silhouette_score"], 9))
+            for row in df.iter_rows(named=True)
+        }
+
+    check("same (geocode, num_clusters, silhouette_score) rows", _rows(rust_out) == _rows(py_out))
+
+
 # --- parquet stage boundary --------------------------------------------------
 
 
@@ -805,6 +840,7 @@ def main() -> None:
     test_build_cluster_significant_differences()
     test_build_permanova_results()
     test_build_geocode_cluster_metrics()
+    test_build_geocode_silhouette_score()
     test_parquet_boundary()
     print("\nAll interop + correctness checks passed.")
 

--- a/bioregion_rs/src/dataframes/geocode_silhouette_score.rs
+++ b/bioregion_rs/src/dataframes/geocode_silhouette_score.rs
@@ -1,0 +1,183 @@
+//! Port of `src/dataframes/geocode_silhouette_score.py`
+//! (`build_geocode_silhouette_score_df`).
+//!
+//! Same underlying formula as `geocode_cluster_metrics.rs`'s mean silhouette
+//! score (read from sklearn's `_unsupervised.py` `_silhouette_reduce`), but
+//! this file needs the *per-point* scores (`silhouette_samples`), not just
+//! their mean.
+
+use std::collections::HashMap;
+
+use polars::prelude::*;
+use pyo3::prelude::*;
+use pyo3_polars::PyDataFrame;
+
+use crate::to_py;
+
+/// Distance between points `i` and `j` in a scipy `pdist`-order condensed
+/// vector for `n` objects; 0.0 when `i == j`.
+fn condensed_dist(condensed: &[f64], n: usize, i: usize, j: usize) -> f64 {
+    if i == j {
+        return 0.0;
+    }
+    let (lo, hi) = if i < j { (i, j) } else { (j, i) };
+    condensed[lo * n - lo * (lo + 1) / 2 + hi - lo - 1]
+}
+
+/// Relabel arbitrary group ids into dense `0..num_groups` indices, ordered by
+/// sorted distinct values (matches sklearn's `LabelEncoder`).
+fn dense_labels(labels: &[u32]) -> (Vec<usize>, usize) {
+    let mut sorted: Vec<u32> = labels.to_vec();
+    sorted.sort_unstable();
+    sorted.dedup();
+    let index_of: HashMap<u32, usize> = sorted.iter().enumerate().map(|(i, &c)| (c, i)).collect();
+    (labels.iter().map(|c| index_of[c]).collect(), sorted.len())
+}
+
+/// Per-point silhouette scores for a precomputed distance matrix. Mirrors
+/// `sklearn.metrics.silhouette_samples(X, labels, metric="precomputed")` (via
+/// `_silhouette_reduce`): for each point, `a` = mean distance to same-cluster
+/// points, `b` = min over other clusters of mean distance to that cluster;
+/// `s = (b-a)/max(a,b)`, `0` for singleton clusters.
+fn silhouette_samples(
+    condensed: &[f64],
+    n: usize,
+    labels: &[usize],
+    num_groups: usize,
+) -> Vec<f64> {
+    let mut group_sizes = vec![0usize; num_groups];
+    for &l in labels {
+        group_sizes[l] += 1;
+    }
+
+    (0..n)
+        .map(|i| {
+            let mut cluster_dist_sum = vec![0.0; num_groups];
+            for j in 0..n {
+                cluster_dist_sum[labels[j]] += condensed_dist(condensed, n, i, j);
+            }
+            let own = labels[i];
+            if group_sizes[own] <= 1 {
+                return 0.0;
+            }
+            let a = cluster_dist_sum[own] / (group_sizes[own] - 1) as f64;
+            let b = (0..num_groups)
+                .filter(|&c| c != own)
+                .map(|c| cluster_dist_sum[c] / group_sizes[c] as f64)
+                .fold(f64::INFINITY, f64::min);
+            let denom = a.max(b);
+            if denom == 0.0 { 0.0 } else { (b - a) / denom }
+        })
+        .collect()
+}
+
+/// Build a GeocodeSilhouetteScoreSchema DataFrame: for every `num_clusters`
+/// value in `geocode_cluster_df`, one row with `geocode = null` holding the
+/// mean silhouette score, followed by one row per geocode holding its
+/// individual silhouette score (in `geocode_cluster_df`'s row order for that
+/// k, matching the distance matrix's row/column order).
+///
+/// Mirrors `build_geocode_silhouette_score_df`. `distance_matrix` is passed
+/// in as its condensed form (`GeocodeDistanceMatrix.condensed()`) directly,
+/// since building it involves UMAP (Phase 3, stays in Python).
+#[pyfunction]
+pub fn build_geocode_silhouette_score(
+    condensed: Vec<f64>,
+    geocode_cluster_df: PyDataFrame,
+) -> PyResult<PyDataFrame> {
+    let geocode_cluster_df: DataFrame = geocode_cluster_df.into();
+
+    let n_squared_2 = 1.0 + 8.0 * condensed.len() as f64;
+    let n = ((1.0 + n_squared_2.sqrt()) / 2.0).round() as usize;
+
+    let num_clusters_ca = geocode_cluster_df
+        .column("num_clusters")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .u32()
+        .map_err(to_py)?
+        .clone();
+    let cluster_ca = geocode_cluster_df
+        .column("cluster")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .u32()
+        .map_err(to_py)?
+        .clone();
+    let geocode_ca = geocode_cluster_df
+        .column("geocode")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .u64()
+        .map_err(to_py)?
+        .clone();
+
+    let mut k_values: Vec<u32> = num_clusters_ca
+        .into_no_null_iter()
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    k_values.sort_unstable();
+
+    let mut out_geocode: Vec<Option<u64>> = Vec::new();
+    let mut out_score: Vec<f64> = Vec::new();
+    let mut out_num_clusters: Vec<u32> = Vec::new();
+
+    for &k in &k_values {
+        let rows: Vec<(u64, u32)> = num_clusters_ca
+            .into_no_null_iter()
+            .zip(geocode_ca.into_no_null_iter())
+            .zip(cluster_ca.into_no_null_iter())
+            .filter(|&((nc, _), _)| nc == k)
+            .map(|((_, g), c)| (g, c))
+            .collect();
+        let raw_labels: Vec<u32> = rows.iter().map(|&(_, c)| c).collect();
+        let (labels, num_groups) = dense_labels(&raw_labels);
+
+        let samples = silhouette_samples(&condensed, n, &labels, num_groups);
+        let mean = samples.iter().sum::<f64>() / n as f64;
+
+        out_geocode.push(None);
+        out_score.push(mean);
+        out_num_clusters.push(k);
+
+        for (&(geocode, _), &score) in rows.iter().zip(&samples) {
+            out_geocode.push(Some(geocode));
+            out_score.push(score);
+            out_num_clusters.push(k);
+        }
+    }
+
+    let geocode_col: UInt64Chunked = out_geocode.into_iter().collect();
+    let out = DataFrame::new(
+        out_score.len(),
+        vec![
+            geocode_col.with_name("geocode".into()).into_column(),
+            Float64Chunked::from_vec("silhouette_score".into(), out_score).into_column(),
+            UInt32Chunked::from_vec("num_clusters".into(), out_num_clusters).into_column(),
+        ],
+    )
+    .map_err(to_py)?;
+
+    Ok(PyDataFrame(out))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn samples_average_to_the_mean_score() {
+        // Same fixture as geocode_cluster_metrics's silhouette test data:
+        // 3 tight pairs, far apart from each other.
+        let condensed = [
+            0.1, 2.0, 2.0, 3.0, 3.0, 2.0, 2.0, 3.0, 3.0, 0.1, 3.0, 3.0, 3.0, 3.0, 0.1,
+        ];
+        let labels = [0usize, 0, 1, 1, 2, 2];
+        let samples = silhouette_samples(&condensed, 6, &labels, 3);
+        assert_eq!(samples.len(), 6);
+        // Tight, well-separated clusters -> every point strongly prefers its
+        // own cluster.
+        assert!(samples.iter().all(|&s| s > 0.9));
+    }
+}

--- a/bioregion_rs/src/dataframes/mod.rs
+++ b/bioregion_rs/src/dataframes/mod.rs
@@ -8,6 +8,7 @@ pub mod cluster_taxa_statistics;
 pub mod geocode;
 pub mod geocode_cluster_metrics;
 pub mod geocode_neighbors;
+pub mod geocode_silhouette_score;
 pub mod geocode_taxa_counts;
 pub mod permanova_results;
 pub mod taxonomy;

--- a/bioregion_rs/src/lib.rs
+++ b/bioregion_rs/src/lib.rs
@@ -81,5 +81,9 @@ fn bioregion_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
         dataframes::geocode_cluster_metrics::select_optimal_k_elbow,
         m
     )?)?;
+    m.add_function(wrap_pyfunction!(
+        dataframes::geocode_silhouette_score::build_geocode_silhouette_score,
+        m
+    )?)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Ports `src/dataframes/geocode_silhouette_score.py::build_geocode_silhouette_score_df` to Rust (`build_geocode_silhouette_score` in `bioregion_rs`).
- Reuses the same per-point silhouette formula from `geocode_cluster_metrics.rs` (both read from sklearn's `_silhouette_reduce`), extended here to emit one score per geocode instead of just the mean.
- Output shape matches Python exactly: for each `num_clusters` value, a leading row with `geocode = null` holding the mean silhouette score, followed by one row per geocode with its individual score, in the same row order as the input (matching the distance matrix's row/column order — the same pre-existing implicit assumption `geocode_cluster_metrics.py` relies on).
- Verified against `build_geocode_silhouette_score_df` in `harness.py` on the same hand-built multi-k fixture used for `geocode_cluster_metrics.py`.

## Test plan
- [x] `cargo test --lib` (22 tests pass)
- [x] `uv run maturin develop --manifest-path bioregion_rs/Cargo.toml`
- [x] `uv run python bioregion_rs/harness.py` (all checks pass, including the new `build_geocode_silhouette_score` check)
- [x] `uv run pyright` (0 errors)
- [x] bioregion_rs CI job will run on this PR's push

https://claude.ai/code/session_01XefuZ41iibHEgQrxWiqDjg