### PR TITLE
Port cluster_optimization.py to Rust

### DIFF
--- a/RUST_MIGRATION_PLAN.md
+++ b/RUST_MIGRATION_PLAN.md
@@ -391,7 +391,14 @@ validated).
   average, matching the Python output shape exactly. Verified against
   `build_geocode_silhouette_score_df` on the same hand-built multi-k fixture used for
   `geocode_cluster_metrics.py`.
-- `src/cluster_optimization.py` — thin orchestration over metrics + elbow. ✅
+- `src/cluster_optimization.py` — ✅ DONE: `optimize_num_clusters`. Genuinely thin
+  orchestration, as the plan predicted: calls the already-ported
+  `build_geocode_cluster_metrics` and `find_elbow_point` directly (in-process, no
+  Python round-trip), falling back to the highest `combined_score` if no elbow point
+  is found. No new math. Verified against Python's `optimize_num_clusters` on the same
+  multi-k fixture used for `geocode_cluster_metrics.py`, deliberately using only 2
+  distinct k values so the test exercises the "no elbow found" fallback path (elbow-found
+  behavior itself is already covered by `geocode_cluster_metrics.py`'s own tests).
 - `src/dataframes/significant_taxa_images.py` — image URL/id lookup join. ✅ (confirm no
   network fetch; if it hits an API, keep that thin bit in Python or use `reqwest`).
 - `src/geojson.py`, `src/output.py`, `src/render.py` — GeoJSON + JSON (+ HTML) emit.

--- a/bioregion_rs/README.md
+++ b/bioregion_rs/README.md
@@ -37,6 +37,8 @@ every subsequent file migration will use.
   - `build_geocode_silhouette_score` — mirrors `src/dataframes/geocode_silhouette_score.py`
     (per-point silhouette scores; same formula as `build_geocode_cluster_metrics`'s
     mean, extended to per-geocode).
+  - `optimize_num_clusters` — mirrors `src/cluster_optimization.py`; thin in-process
+    orchestration over `build_geocode_cluster_metrics` + `find_elbow_point`.
 - `harness.py` — runs each Rust function and its Python counterpart on the same
   input and asserts they match. The template for migrating each file.
 

--- a/bioregion_rs/harness.py
+++ b/bioregion_rs/harness.py
@@ -22,6 +22,7 @@ import shapely
 from scipy.spatial.distance import squareform
 
 import bioregion_rs
+from src.cluster_optimization import optimize_num_clusters
 from src.colors import darken_hex_color as py_darken
 from src.dataframes.cluster_boundary import build_cluster_boundary_df
 from src.dataframes.cluster_color import build_cluster_color_df
@@ -805,6 +806,37 @@ def test_build_geocode_silhouette_score() -> None:
     check("same (geocode, num_clusters, silhouette_score) rows", _rows(rust_out) == _rows(py_out))
 
 
+# --- src/cluster_optimization.py -----------------------------------------------
+
+
+def test_optimize_num_clusters() -> None:
+    print("src/cluster_optimization.py  (optimize_num_clusters):")
+    # Only 2 distinct k values (2, 3) are tested here, which is below
+    # _find_elbow_point's own `len(df) < 3` minimum -- so this specifically
+    # exercises the "no elbow found, fall back to highest combined_score"
+    # path. Elbow-found behavior itself is already covered by
+    # geocode_cluster_metrics.py's own tests; this file is pure orchestration
+    # on top of that.
+    condensed, geocode_cluster_multi_k_df, distance_matrix = (
+        _six_point_three_pair_fixture()
+    )
+
+    rust_k, rust_metrics = bioregion_rs.optimize_num_clusters(
+        condensed, geocode_cluster_multi_k_df
+    )
+    py_k, py_metrics = optimize_num_clusters(distance_matrix, geocode_cluster_multi_k_df)
+
+    check(f"same optimal k (rust={rust_k}, py={py_k})", rust_k == py_k)
+
+    def _rows(df: pl.DataFrame) -> set:
+        return {
+            (row["num_clusters"], round(row["combined_score"], 6))
+            for row in df.iter_rows(named=True)
+        }
+
+    check("same metrics table (combined_score by k)", _rows(rust_metrics) == _rows(py_metrics))
+
+
 # --- parquet stage boundary --------------------------------------------------
 
 
@@ -841,6 +873,7 @@ def main() -> None:
     test_build_permanova_results()
     test_build_geocode_cluster_metrics()
     test_build_geocode_silhouette_score()
+    test_optimize_num_clusters()
     test_parquet_boundary()
     print("\nAll interop + correctness checks passed.")
 

--- a/bioregion_rs/src/cluster_optimization.rs
+++ b/bioregion_rs/src/cluster_optimization.rs
@@ -1,0 +1,87 @@
+//! Port of `src/cluster_optimization.py` (`optimize_num_clusters`).
+//!
+//! Thin orchestration over already-ported pieces: build the full cluster
+//! validation metrics table (`geocode_cluster_metrics::build_geocode_cluster_metrics`),
+//! then pick `k` via the elbow method
+//! (`geocode_cluster_metrics::find_elbow_point`), falling back to the `k`
+//! with the highest `combined_score` if no elbow point is found.
+
+use polars::prelude::*;
+use pyo3::prelude::*;
+use pyo3_polars::PyDataFrame;
+
+use crate::dataframes::geocode_cluster_metrics::{build_geocode_cluster_metrics, find_elbow_point};
+use crate::to_py;
+
+/// Find the optimal number of clusters via the elbow method, computing
+/// cluster validation metrics for every `num_clusters` value along the way.
+///
+/// Mirrors `optimize_num_clusters`. Returns `(optimal_k, metrics_df)`.
+#[pyfunction]
+#[pyo3(signature = (
+    condensed, geocode_cluster_df, elbow_sensitivity = 1.0,
+    weight_silhouette = 0.4, weight_calinski_harabasz = 0.3, weight_davies_bouldin = 0.3,
+))]
+#[allow(clippy::too_many_arguments)]
+pub fn optimize_num_clusters(
+    condensed: Vec<f64>,
+    geocode_cluster_df: PyDataFrame,
+    elbow_sensitivity: f64,
+    weight_silhouette: f64,
+    weight_calinski_harabasz: f64,
+    weight_davies_bouldin: f64,
+) -> PyResult<(u32, PyDataFrame)> {
+    let metrics_df: DataFrame = build_geocode_cluster_metrics(
+        condensed,
+        geocode_cluster_df,
+        weight_silhouette,
+        weight_calinski_harabasz,
+        weight_davies_bouldin,
+    )?
+    .0;
+
+    // build_geocode_cluster_metrics already emits rows in ascending
+    // num_clusters order, matching find_elbow_point's "x sorted ascending"
+    // requirement.
+    let num_clusters_ca = metrics_df
+        .column("num_clusters")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .u32()
+        .map_err(to_py)?
+        .clone();
+    let inertia_ca = metrics_df
+        .column("inertia")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .f64()
+        .map_err(to_py)?
+        .clone();
+    let k_values: Vec<f64> = num_clusters_ca.into_no_null_iter().map(f64::from).collect();
+    let inertia_values: Vec<f64> = inertia_ca.into_no_null_iter().collect();
+
+    let optimal_k: u32 = match find_elbow_point(&k_values, &inertia_values, elbow_sensitivity) {
+        Some(k) => k.round() as u32,
+        None => {
+            // Fallback: k with the highest combined_score.
+            let combined_ca = metrics_df
+                .column("combined_score")
+                .map_err(to_py)?
+                .as_materialized_series()
+                .f64()
+                .map_err(to_py)?
+                .clone();
+            let best_idx = combined_ca
+                .into_no_null_iter()
+                .enumerate()
+                .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+                .map(|(i, _)| i)
+                .expect("metrics_df has at least one row");
+            num_clusters_ca
+                .get(best_idx)
+                .expect("combined_score and num_clusters columns have equal length")
+        }
+    };
+
+    Ok((optimal_k, PyDataFrame(metrics_df)))
+}

--- a/bioregion_rs/src/lib.rs
+++ b/bioregion_rs/src/lib.rs
@@ -10,6 +10,7 @@ use polars::prelude::PolarsError;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
+mod cluster_optimization;
 mod colors;
 mod dataframes;
 mod geocode;
@@ -83,6 +84,10 @@ fn bioregion_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     )?)?;
     m.add_function(wrap_pyfunction!(
         dataframes::geocode_silhouette_score::build_geocode_silhouette_score,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(
+        cluster_optimization::optimize_num_clusters,
         m
     )?)?;
     Ok(())


### PR DESCRIPTION
## Summary
- Ports `src/cluster_optimization.py::optimize_num_clusters` to Rust (`optimize_num_clusters` in `bioregion_rs`).
- Genuinely thin orchestration, as the plan predicted: calls the already-ported `build_geocode_cluster_metrics` and `find_elbow_point` directly, in-process (no Python round-trip needed since both already live in this crate), falling back to the `k` with the highest `combined_score` when no elbow point is found. No new math — this file is pure glue.
- Verified against Python's `optimize_num_clusters` in `harness.py` on the same multi-k fixture used for `geocode_cluster_metrics.py`, deliberately using only 2 distinct k values so the test exercises the "no elbow found, fall back to combined_score" path (the elbow-found path itself is already covered by `geocode_cluster_metrics.py`'s own tests, so this test's job is just to verify the orchestration).

## Test plan
- [x] `cargo test --lib` (22 tests pass)
- [x] `uv run maturin develop --manifest-path bioregion_rs/Cargo.toml`
- [x] `uv run python bioregion_rs/harness.py` (all checks pass, including the new `optimize_num_clusters` check)
- [x] `uv run pyright` (0 errors)
- [x] bioregion_rs CI job will run on this PR's push

https://claude.ai/code/session_01XefuZ41iibHEgQrxWiqDjg