### PR TITLE
Phase 2: port src/output.py's write_json_output to Rust

### DIFF
--- a/RUST_MIGRATION_PLAN.md
+++ b/RUST_MIGRATION_PLAN.md
@@ -434,7 +434,26 @@ validated).
   `MultiPolygon` clusters, exercising both shapes): properties compared exactly,
   geometry compared with the same relative-tolerance check as
   `cluster_boundary.py` (same underlying `geo`-vs-GEOS union discrepancy).
-- `src/output.py`, `src/render.py` — TODO: JSON (+ HTML) emit, not yet ported.
+- `src/output.py` — ✅ DONE (`build_json_output` in `output.rs`, mirrors
+  `write_json_output`'s assembly logic). Joins `cluster_boundary_df` with
+  `cluster_color_df` (inner), and per cluster, `cluster_significant_differences_df`
+  with `taxonomy_df` (inner) and `significant_taxa_images_df` (left) — a taxonId
+  missing from `taxonomy_df` is dropped, one missing from
+  `significant_taxa_images_df` gets a null `image_url`, matching Python's join
+  semantics exactly. Boundary WKB is converted to a GeoJSON geometry via the same
+  `wkb::decode_geometry` + `geojson` crate path as `geojson.rs`. Returns the
+  assembled JSON as a `String` rather than writing it — `prepare_file_path` +
+  the actual file write stay in Python (I/O, not compute; no pipeline call site
+  cut over yet, same rationale as `geojson.rs`'s `write_geojson`). Verified in
+  `harness.py` against a hand-built fixture (reusing
+  `test_build_cluster_significant_differences`'s data) that deliberately
+  exercises both join edge cases (a dropped taxonId, a null `image_url`);
+  `significant_taxa` lists are compared as order-independent sets since neither
+  implementation's join guarantees row order.
+- `src/render.py` (`features_to_polars_df`) — 🔴 NOT PORTED, likely dead code:
+  confirmed via repo-wide grep that this function is referenced only by its own
+  test (`test/test_render.py`), not by `notebook.py` or any other pipeline file.
+  Not worth porting unless something starts calling it.
 
 ### Phase 3 — hard ML kernels (🔴 keep in Python until validated)
 

--- a/bioregion_rs/Cargo.lock
+++ b/bioregion_rs/Cargo.lock
@@ -118,6 +118,7 @@ dependencies = [
  "pyo3",
  "pyo3-polars",
  "rand 0.9.5",
+ "serde_json",
 ]
 
 [[package]]

--- a/bioregion_rs/Cargo.toml
+++ b/bioregion_rs/Cargo.toml
@@ -37,3 +37,7 @@ pyo3-polars = "0.27"
 # Already resolved transitively (polars depends on rand 0.9.5); pinned here to
 # match, for the PERMANOVA permutation test's Monte Carlo shuffling.
 rand = "0.9"
+# Already resolved transitively (the geojson crate depends on it); used
+# directly in output.rs to build the plain (non-GeoJSON-FeatureCollection)
+# JSON array that write_json_output produces.
+serde_json = "1.0"

--- a/bioregion_rs/README.md
+++ b/bioregion_rs/README.md
@@ -44,6 +44,9 @@ every subsequent file migration will use.
     property-swap bug), returning the FeatureCollection as a JSON string rather than a
     `geojson.FeatureCollection` Python object (nothing in the codebase does an
     `isinstance` check against that type).
+  - `build_json_output` — mirrors `src/output.py`'s `write_json_output` (the
+    join/assembly logic; the actual file write stays in Python, same as
+    `geojson.rs`'s `write_geojson`). Returns the assembled JSON as a `String`.
 - `harness.py` — runs each Rust function and its Python counterpart on the same
   input and asserts they match. The template for migrating each file.
 

--- a/bioregion_rs/harness.py
+++ b/bioregion_rs/harness.py
@@ -57,6 +57,7 @@ from src.geojson import build_geojson_feature_collection
 from src.matrices.cluster_distance import ClusterDistanceMatrix
 from src.matrices.geocode_connectivity import GeocodeConnectivityMatrix
 from src.matrices.geocode_distance import GeocodeDistanceMatrix
+from src.output import write_json_output
 from src.types import Bbox
 
 
@@ -922,6 +923,161 @@ def test_build_geojson_feature_collection() -> None:
     )
 
 
+def test_write_json_output() -> None:
+    print("src/output.py  (write_json_output):")
+
+    # Reuses test_build_cluster_significant_differences's fixture (its real
+    # taxa counts clear MIN_COUNT_THRESHOLD=5 and produce a non-trivial
+    # result set to build the rest of this test's fixtures on top of).
+    all_stats = pl.DataFrame(
+        {
+            "cluster": [0, 0, 1, 1, 2, 2],
+            "taxonId": [1, 2, 1, 2, 1, 2],
+            "count": [50, 10, 5, 55, 30, 30],
+            "average": [0.0] * 6,
+        }
+    ).cast(
+        {
+            "cluster": pl.UInt32,
+            "taxonId": pl.UInt32,
+            "count": pl.UInt32,
+            "average": pl.Float64,
+        }
+    )
+    cluster_neighbors_df = pl.DataFrame(
+        {
+            "cluster": [0, 1, 2],
+            "direct_neighbors": [[1], [0, 2], [1]],
+            "direct_and_indirect_neighbors": [[1], [0, 2], [1]],
+        }
+    ).cast(
+        {
+            "cluster": pl.UInt32,
+            "direct_neighbors": pl.List(pl.UInt32),
+            "direct_and_indirect_neighbors": pl.List(pl.UInt32),
+        }
+    )
+    cluster_significant_differences_df = build_cluster_significant_differences_df(
+        all_stats, cluster_neighbors_df.lazy()
+    )
+    check(
+        f"non-trivial: {cluster_significant_differences_df.height} significant differences",
+        cluster_significant_differences_df.height > 0,
+    )
+
+    clusters_present = (
+        cluster_significant_differences_df["cluster"].unique().sort().to_list()
+    )
+    cluster_boundary_df = pl.DataFrame(
+        {
+            "cluster": clusters_present,
+            "geometry": [
+                shapely.to_wkb(shapely.geometry.box(i, i, i + 1, i + 1))
+                for i in range(len(clusters_present))
+            ],
+        }
+    ).cast({"cluster": pl.UInt32, "geometry": pl.Binary})
+    cluster_color_df = pl.DataFrame(
+        {
+            "cluster": clusters_present,
+            "color": [f"#{i:02x}{i:02x}{i:02x}" for i in range(len(clusters_present))],
+            "darkened_color": [
+                py_darken(f"#{i:02x}{i:02x}{i:02x}") for i in range(len(clusters_present))
+            ],
+        }
+    ).cast({"cluster": pl.UInt32, "color": pl.String, "darkened_color": pl.String})
+
+    # Exercise both join edge cases write_json_output relies on: a taxonId
+    # present in the significant differences but absent from taxonomy_df is
+    # dropped (inner join), and a taxonId present in taxonomy_df but absent
+    # from significant_taxa_images_df gets a null image_url (left join).
+    present_taxon_ids = (
+        cluster_significant_differences_df["taxonId"].unique().sort().to_list()
+    )
+    taxonomy_taxon_ids = (
+        present_taxon_ids[:-1] if len(present_taxon_ids) > 1 else present_taxon_ids
+    )
+    taxonomy_df = pl.DataFrame(
+        {
+            "taxonId": taxonomy_taxon_ids,
+            "scientificName": [f"Taxon {t}" for t in taxonomy_taxon_ids],
+            "gbifTaxonId": [1000 + t for t in taxonomy_taxon_ids],
+        }
+    ).cast(
+        {"taxonId": pl.UInt32, "scientificName": pl.String, "gbifTaxonId": pl.UInt32}
+    )
+    images_taxon_ids = (
+        taxonomy_taxon_ids[:-1] if len(taxonomy_taxon_ids) > 1 else []
+    )
+    significant_taxa_images_df = pl.DataFrame(
+        {
+            "taxonId": images_taxon_ids,
+            "image_url": [f"https://example.com/{t}.jpg" for t in images_taxon_ids],
+        }
+    ).cast({"taxonId": pl.UInt32, "image_url": pl.String})
+
+    rust_json = bioregion_rs.build_json_output(
+        cluster_significant_differences_df,
+        cluster_boundary_df,
+        taxonomy_df,
+        cluster_color_df,
+        significant_taxa_images_df,
+    )
+    rust_parsed = json.loads(rust_json)
+
+    with tempfile.TemporaryDirectory() as d:
+        out_path = str(Path(d) / "output.json")
+        write_json_output(
+            cluster_significant_differences_df,
+            cluster_boundary_df,
+            taxonomy_df,
+            cluster_color_df,
+            significant_taxa_images_df,
+            out_path,
+        )
+        with open(out_path) as f:
+            py_parsed = json.load(f)
+
+    check(f"non-trivial: {len(py_parsed)} clusters", len(py_parsed) > 1)
+    check("dropped a taxonId missing from taxonomy_df", len(taxonomy_taxon_ids) < len(present_taxon_ids))
+    check("left a taxonId's image_url null", len(images_taxon_ids) < len(taxonomy_taxon_ids))
+
+    def _by_cluster(entries: list) -> dict:
+        return {e["cluster"]: e for e in entries}
+
+    rust_by_cluster = _by_cluster(rust_parsed)
+    py_by_cluster = _by_cluster(py_parsed)
+    check("same cluster set", set(rust_by_cluster) == set(py_by_cluster))
+    check(
+        "same color/darkened_color per cluster",
+        all(
+            rust_by_cluster[c]["color"] == py_by_cluster[c]["color"]
+            and rust_by_cluster[c]["darkened_color"] == py_by_cluster[c]["darkened_color"]
+            for c in rust_by_cluster
+        ),
+    )
+    check(
+        "same boundary geometry per cluster",
+        all(
+            rust_by_cluster[c]["boundary"] == py_by_cluster[c]["boundary"]
+            for c in rust_by_cluster
+        ),
+    )
+
+    def _taxa_set(entry: dict) -> set:
+        # Order isn't guaranteed by either implementation's join, so compare
+        # as a set of rows rather than an exact list.
+        return {tuple(sorted(t.items())) for t in entry["significant_taxa"]}
+
+    check(
+        "same significant_taxa per cluster (order-independent)",
+        all(
+            _taxa_set(rust_by_cluster[c]) == _taxa_set(py_by_cluster[c])
+            for c in rust_by_cluster
+        ),
+    )
+
+
 # --- parquet stage boundary --------------------------------------------------
 
 
@@ -960,6 +1116,7 @@ def main() -> None:
     test_build_geocode_silhouette_score()
     test_optimize_num_clusters()
     test_build_geojson_feature_collection()
+    test_write_json_output()
     test_parquet_boundary()
     print("\nAll interop + correctness checks passed.")
 

--- a/bioregion_rs/src/lib.rs
+++ b/bioregion_rs/src/lib.rs
@@ -16,6 +16,7 @@ mod dataframes;
 mod geocode;
 mod geojson;
 mod matrices;
+mod output;
 mod wkb;
 
 /// Convert a polars error into a Python `ValueError`.
@@ -95,5 +96,6 @@ fn bioregion_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
         geojson::build_geojson_feature_collection,
         m
     )?)?;
+    m.add_function(wrap_pyfunction!(output::build_json_output, m)?)?;
     Ok(())
 }

--- a/bioregion_rs/src/output.rs
+++ b/bioregion_rs/src/output.rs
@@ -1,0 +1,328 @@
+//! Port of `src/output.py`'s `write_json_output`.
+//!
+//! `write_json_output` itself is a thin file-write wrapper around building a
+//! JSON document; the actual assembly (joins + geometry conversion) is the
+//! part worth porting. This module returns the assembled JSON as a `String`
+//! and leaves `prepare_file_path`/`open(...).write(...)` in Python, matching
+//! the `geojson.rs` precedent (I/O stays in Python; this crate hasn't cut
+//! over any pipeline call sites yet, see `RUST_MIGRATION_PLAN.md`).
+//!
+//! Boundary geometry is converted to a GeoJSON geometry object via the same
+//! `wkb::decode_geometry` + `geojson` crate path as `geojson.rs`, which is
+//! the Rust equivalent of Python's `shapely.to_geojson(shapely.from_wkb(...))`.
+
+use polars::prelude::*;
+use pyo3::prelude::*;
+use pyo3_polars::PyDataFrame;
+use serde_json::{Value, json};
+use std::collections::HashMap;
+
+use crate::to_py;
+use crate::wkb;
+
+fn wkb_to_geojson_value(bytes: &[u8]) -> Value {
+    let geom = wkb::decode_geometry(bytes);
+    let geojson_geom = match &geom {
+        wkb::Geometry::Polygon(poly) => geojson::Geometry::from(poly),
+        wkb::Geometry::MultiPolygon(mp) => geojson::Geometry::from(mp),
+    };
+    serde_json::to_value(geojson_geom).expect("geojson::Geometry always serializes")
+}
+
+struct SignificantDiffRow {
+    taxon_id: u32,
+    log2_fold_change: f64,
+    cluster_count: u32,
+    neighbor_count: u32,
+    high_log2_high_count_score: f64,
+    low_log2_high_count_score: f64,
+}
+
+/// Build the same JSON document as `write_json_output` (as a string, prior to
+/// the file write), joining cluster boundaries/colors and, per cluster, its
+/// significant taxa (with taxonomy and, where available, an image URL).
+#[pyfunction]
+pub fn build_json_output(
+    cluster_significant_differences_df: PyDataFrame,
+    cluster_boundary_df: PyDataFrame,
+    taxonomy_df: PyDataFrame,
+    cluster_color_df: PyDataFrame,
+    significant_taxa_images_df: PyDataFrame,
+) -> PyResult<String> {
+    let diffs_df: DataFrame = cluster_significant_differences_df.into();
+    let boundary_df: DataFrame = cluster_boundary_df.into();
+    let taxonomy_df: DataFrame = taxonomy_df.into();
+    let colors_df: DataFrame = cluster_color_df.into();
+    let images_df: DataFrame = significant_taxa_images_df.into();
+
+    // taxonId -> (scientificName, gbifTaxonId)
+    let taxonomy: HashMap<u32, (Option<String>, u32)> = {
+        let taxon_id_ca = taxonomy_df
+            .column("taxonId")
+            .map_err(to_py)?
+            .as_materialized_series()
+            .u32()
+            .map_err(to_py)?
+            .clone();
+        let sci_name_ca = taxonomy_df
+            .column("scientificName")
+            .map_err(to_py)?
+            .as_materialized_series()
+            .str()
+            .map_err(to_py)?
+            .clone();
+        let gbif_ca = taxonomy_df
+            .column("gbifTaxonId")
+            .map_err(to_py)?
+            .as_materialized_series()
+            .u32()
+            .map_err(to_py)?
+            .clone();
+        taxon_id_ca
+            .into_no_null_iter()
+            .zip(sci_name_ca.iter())
+            .zip(gbif_ca.into_no_null_iter())
+            .map(|((taxon_id, sci_name), gbif_id)| {
+                (taxon_id, (sci_name.map(|s| s.to_string()), gbif_id))
+            })
+            .collect()
+    };
+
+    // taxonId -> image_url (left join: missing key means null image_url)
+    let images: HashMap<u32, Option<String>> = {
+        let taxon_id_ca = images_df
+            .column("taxonId")
+            .map_err(to_py)?
+            .as_materialized_series()
+            .u32()
+            .map_err(to_py)?
+            .clone();
+        let url_ca = images_df
+            .column("image_url")
+            .map_err(to_py)?
+            .as_materialized_series()
+            .str()
+            .map_err(to_py)?
+            .clone();
+        taxon_id_ca
+            .into_no_null_iter()
+            .zip(url_ca.iter())
+            .map(|(taxon_id, url)| (taxon_id, url.map(|s| s.to_string())))
+            .collect()
+    };
+
+    // cluster -> (color, darkened_color)
+    let colors: HashMap<u32, (String, String)> = {
+        let cluster_ca = colors_df
+            .column("cluster")
+            .map_err(to_py)?
+            .as_materialized_series()
+            .u32()
+            .map_err(to_py)?
+            .clone();
+        let color_ca = colors_df
+            .column("color")
+            .map_err(to_py)?
+            .as_materialized_series()
+            .str()
+            .map_err(to_py)?
+            .clone();
+        let darkened_ca = colors_df
+            .column("darkened_color")
+            .map_err(to_py)?
+            .as_materialized_series()
+            .str()
+            .map_err(to_py)?
+            .clone();
+        cluster_ca
+            .into_no_null_iter()
+            .zip(color_ca.iter())
+            .zip(darkened_ca.iter())
+            .map(|((c, color), darkened)| {
+                (
+                    c,
+                    (
+                        color.expect("color column must be non-null").to_string(),
+                        darkened
+                            .expect("darkened_color column must be non-null")
+                            .to_string(),
+                    ),
+                )
+            })
+            .collect()
+    };
+
+    // cluster -> significant-difference rows for that cluster, in original
+    // row order (mirrors Python's filter(), which preserves row order).
+    let mut diffs_by_cluster: HashMap<u32, Vec<SignificantDiffRow>> = HashMap::new();
+    {
+        let cluster_ca = diffs_df
+            .column("cluster")
+            .map_err(to_py)?
+            .as_materialized_series()
+            .u32()
+            .map_err(to_py)?
+            .clone();
+        let taxon_id_ca = diffs_df
+            .column("taxonId")
+            .map_err(to_py)?
+            .as_materialized_series()
+            .u32()
+            .map_err(to_py)?
+            .clone();
+        let log2_ca = diffs_df
+            .column("log2_fold_change")
+            .map_err(to_py)?
+            .as_materialized_series()
+            .f64()
+            .map_err(to_py)?
+            .clone();
+        let cluster_count_ca = diffs_df
+            .column("cluster_count")
+            .map_err(to_py)?
+            .as_materialized_series()
+            .u32()
+            .map_err(to_py)?
+            .clone();
+        let neighbor_count_ca = diffs_df
+            .column("neighbor_count")
+            .map_err(to_py)?
+            .as_materialized_series()
+            .u32()
+            .map_err(to_py)?
+            .clone();
+        let high_ca = diffs_df
+            .column("high_log2_high_count_score")
+            .map_err(to_py)?
+            .as_materialized_series()
+            .f64()
+            .map_err(to_py)?
+            .clone();
+        let low_ca = diffs_df
+            .column("low_log2_high_count_score")
+            .map_err(to_py)?
+            .as_materialized_series()
+            .f64()
+            .map_err(to_py)?
+            .clone();
+
+        for i in 0..diffs_df.height() {
+            let cluster = cluster_ca.get(i).expect("cluster column must be non-null");
+            diffs_by_cluster
+                .entry(cluster)
+                .or_default()
+                .push(SignificantDiffRow {
+                    taxon_id: taxon_id_ca.get(i).expect("taxonId column must be non-null"),
+                    log2_fold_change: log2_ca
+                        .get(i)
+                        .expect("log2_fold_change column must be non-null"),
+                    cluster_count: cluster_count_ca
+                        .get(i)
+                        .expect("cluster_count column must be non-null"),
+                    neighbor_count: neighbor_count_ca
+                        .get(i)
+                        .expect("neighbor_count column must be non-null"),
+                    high_log2_high_count_score: high_ca
+                        .get(i)
+                        .expect("high_log2_high_count_score column must be non-null"),
+                    low_log2_high_count_score: low_ca
+                        .get(i)
+                        .expect("low_log2_high_count_score column must be non-null"),
+                });
+        }
+    }
+
+    let cluster_ca = boundary_df
+        .column("cluster")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .u32()
+        .map_err(to_py)?
+        .clone();
+    let geometry_ca = boundary_df
+        .column("geometry")
+        .map_err(to_py)?
+        .as_materialized_series()
+        .binary()
+        .map_err(to_py)?
+        .clone();
+
+    let mut output_data: Vec<Value> = Vec::new();
+    for (cluster, geometry_bytes) in cluster_ca.into_no_null_iter().zip(geometry_ca.iter()) {
+        // inner join: skip clusters with no matching color row
+        let Some((color, darkened_color)) = colors.get(&cluster) else {
+            continue;
+        };
+        let boundary =
+            wkb_to_geojson_value(geometry_bytes.expect("geometry column must be non-null"));
+
+        let mut significant_taxa: Vec<Value> = Vec::new();
+        if let Some(rows) = diffs_by_cluster.get(&cluster) {
+            for row in rows {
+                // inner join with taxonomy_df: skip taxa with no taxonomy row
+                let Some((scientific_name, gbif_taxon_id)) = taxonomy.get(&row.taxon_id) else {
+                    continue;
+                };
+                // left join with significant_taxa_images_df: missing key -> null
+                let image_url = images.get(&row.taxon_id).cloned().flatten();
+                significant_taxa.push(json!({
+                    "scientific_name": scientific_name,
+                    "gbif_taxon_id": gbif_taxon_id,
+                    "taxon_id": row.taxon_id,
+                    "log2_fold_change": row.log2_fold_change,
+                    "cluster_count": row.cluster_count,
+                    "neighbor_count": row.neighbor_count,
+                    "high_log2_high_count_score": row.high_log2_high_count_score,
+                    "low_log2_high_count_score": row.low_log2_high_count_score,
+                    "image_url": image_url,
+                }));
+            }
+        }
+
+        output_data.push(json!({
+            "cluster": cluster,
+            "boundary": boundary,
+            "significant_taxa": significant_taxa,
+            "color": color,
+            "darkened_color": darkened_color,
+        }));
+    }
+
+    serde_json::to_string_pretty(&output_data)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_image_and_missing_taxonomy_are_handled() {
+        let ring = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 0.0)];
+        let poly = crate::wkb::decode_polygon(&crate::wkb::polygon(&ring));
+        let bytes = crate::wkb::encode_polygon(&poly);
+
+        let mut taxonomy = HashMap::new();
+        taxonomy.insert(1u32, (Some("Taxon One".to_string()), 100u32));
+        // taxon 2 intentionally absent -- should be dropped (inner join)
+
+        let mut images = HashMap::new();
+        images.insert(1u32, Some("https://example.com/1.jpg".to_string()));
+        // taxon absent from images map -> null image_url (left join)
+
+        assert_eq!(
+            taxonomy.get(&2u32),
+            None,
+            "taxon 2 has no taxonomy row and must be excluded from significant_taxa"
+        );
+        assert_eq!(
+            images.get(&1u32).cloned().flatten(),
+            Some("https://example.com/1.jpg".to_string())
+        );
+        assert_eq!(images.get(&99u32).cloned().flatten(), None);
+
+        // sanity: geometry conversion doesn't panic on a plain polygon
+        let value = wkb_to_geojson_value(&bytes);
+        assert_eq!(value["type"], "Polygon");
+    }
+}


### PR DESCRIPTION
## Summary
- Ports `write_json_output`'s join/assembly logic to `bioregion_rs::build_json_output`: joins `cluster_boundary_df` + `cluster_color_df` (inner), and per cluster, `cluster_significant_differences_df` with `taxonomy_df` (inner) and `significant_taxa_images_df` (left) — a taxonId missing from taxonomy is dropped, one missing an image gets a null `image_url`.
- Reuses the `wkb::decode_geometry` + `geojson` crate path from `geojson.rs` to convert boundary WKB to a GeoJSON geometry, matching Python's `shapely.to_geojson(shapely.from_wkb(...))`.
- Returns the assembled JSON as a `String`; the actual file write (`prepare_file_path` + `open().write()`) stays in Python — I/O, not compute, same as `geojson.rs`'s `write_geojson`. No pipeline call site is cut over yet.
- `src/render.py`'s `features_to_polars_df` is confirmed dead code (grep shows it's referenced only by its own test) and is left unported; noted in the plan.

## Test plan
- [x] `cargo test --lib` — 26 passed (new: `output::tests::missing_image_and_missing_taxonomy_are_handled`)
- [x] `cargo clippy --lib` — no new warnings
- [x] `cargo fmt --check` — clean
- [x] `uv run python bioregion_rs/harness.py` — all checks pass, including new `test_write_json_output` (hand-built fixture exercising both join edge cases: a dropped taxonId and a null `image_url`; `significant_taxa` compared as order-independent sets since join order isn't guaranteed by either implementation)

https://claude.ai/code/session_01XefuZ41iibHEgQrxWiqDjg