### PR TITLE
Wire bioregion_rs into the root project as a uv workspace dependency

### DIFF
--- a/.github/workflows/bioregion-rs.yml
+++ b/.github/workflows/bioregion-rs.yml
@@ -17,10 +17,17 @@ jobs:
       - name: Cache cargo registry and build artifacts
         uses: actions/cache@v4
         with:
+          # NOTE: deliberately excludes bioregion_rs/target/wheels -- maturin's
+          # PEP 517 build backend (invoked by `uv sync` below) can reuse an
+          # existing wheel it finds there without reinvoking cargo, which would
+          # silently ship a stale extension if that directory were cached
+          # across runs. Caching only the compiled objects still makes rebuilds
+          # fast; the wheel itself is always packaged fresh from current source.
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            bioregion_rs/target
+            bioregion_rs/target/debug
+            bioregion_rs/target/release
           key: ${{ runner.os }}-cargo-${{ hashFiles('bioregion_rs/Cargo.lock') }}
       - name: cargo test (Rust unit tests)
         working-directory: bioregion_rs
@@ -34,6 +41,8 @@ jobs:
             LD_LIBRARY_PATH="$PYTHON_LIBDIR:$LD_LIBRARY_PATH" \
             cargo test --lib
       - name: Build the bioregion_rs extension into the venv
-        run: uv run maturin develop --manifest-path bioregion_rs/Cargo.toml
+        # bioregion-rs is now a uv workspace member (see root pyproject.toml),
+        # so `uv sync` builds and installs it like any other dependency.
+        run: uv sync
       - name: Run interop/correctness harness (Rust output vs Python output)
         run: uv run python bioregion_rs/harness.py

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -41,6 +41,20 @@ jobs:
       - uses: "google-github-actions/auth@v3"
         with:
           credentials_json: "${{ secrets.GCP_SERVICE_ACCOUNT }}"
+      - name: Install Rust
+        # bioregion-rs is a uv workspace member (see root pyproject.toml);
+        # `uv sync`/`uv run` below build it via maturin, which needs cargo.
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo registry and build artifacts
+        uses: actions/cache@v4
+        with:
+          # Excludes bioregion_rs/target/wheels -- see bioregion-rs.yml for why.
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            bioregion_rs/target/debug
+            bioregion_rs/target/release
+          key: ${{ runner.os }}-cargo-${{ hashFiles('bioregion_rs/Cargo.lock') }}
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v4
         with:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -6,11 +6,25 @@ jobs:
   unittest:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Rust
+        # bioregion-rs is a uv workspace member (see root pyproject.toml);
+        # `uv run` below builds it via maturin, which needs cargo.
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo registry and build artifacts
+        uses: actions/cache@v4
+        with:
+          # Excludes bioregion_rs/target/wheels -- see bioregion-rs.yml for why.
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            bioregion_rs/target/debug
+            bioregion_rs/target/release
+          key: ${{ runner.os }}-cargo-${{ hashFiles('bioregion_rs/Cargo.lock') }}
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
-      - name: Checkout
-        uses: actions/checkout@v3
       - name: Run unit tests
         run: uv run python -m unittest

--- a/bioregion_rs/README.md
+++ b/bioregion_rs/README.md
@@ -51,7 +51,34 @@ every subsequent file migration will use.
   input and asserts they match. The template for migrating each file.
 
 CI (`.github/workflows/bioregion-rs.yml`) runs `cargo test --lib`, builds the
-extension via `maturin develop`, and runs `harness.py` on every push.
+extension via `uv sync`, and runs `harness.py` on every push.
+
+## Packaging
+
+`bioregion_rs` is a `uv` workspace member of the root project (see the root
+`pyproject.toml`'s `[tool.uv.workspace]`/`[tool.uv.sources]`), declared as a
+dependency under its PEP 503 name `bioregion-rs` (hyphen) — the importable
+module name stays `bioregion_rs` (underscore), set via this crate's own
+`pyproject.toml` (`[tool.maturin] module-name`). Plain `uv sync`/`uv run` from
+the repo root build and install it like any other dependency, which means a
+Rust toolchain must be on `PATH` for that to succeed (this crate has no
+published prebuilt wheels).
+
+`bioregion_rs.pyi` is a hand-maintained type stub for pyright (PyO3/maturin
+extensions don't auto-generate stubs); maturin bundles it into the wheel
+automatically since it lives at the project root next to `Cargo.toml`. Keep it
+in sync whenever a `#[pyfunction]`'s signature changes.
+
+**Gotcha:** `bioregion_rs/target/wheels/` can hold a stale pre-built wheel that
+maturin's PEP 517 build backend may reuse without reinvoking `cargo` if that
+directory persists across builds (confirmed by hand: a source-only change,
+even via `touch`, wasn't picked up by a subsequent `uv sync` once a wheel
+already existed there). This can't happen in CI (each job starts from a clean
+checkout), but the `actions/cache@v4` steps in `bioregion-rs.yml`/`run.yml`/
+`unittest.yml` deliberately exclude `bioregion_rs/target/wheels` from what
+gets cached, to be safe. Locally, if `uv sync` seems to have skipped a rebuild
+after editing `.rs` source, run `uv sync --reinstall-package bioregion-rs`
+(or delete `bioregion_rs/target/wheels/` first).
 
 ## Build & test
 
@@ -59,8 +86,9 @@ extension via `maturin develop`, and runs `harness.py` on every push.
 # Rust unit tests (pure logic; needs a Python on PATH for pyo3 linking):
 cargo test --lib
 
-# Build the extension into the project venv:
-uv run maturin develop --manifest-path bioregion_rs/Cargo.toml
+# Build the extension into the project venv (also runs automatically on any
+# `uv run`/`uv sync` once bioregion-rs is a declared dependency):
+uv sync
 
 # Correctness / interop harness (Rust output vs Python output):
 uv run python bioregion_rs/harness.py

--- a/bioregion_rs/bioregion_rs.pyi
+++ b/bioregion_rs/bioregion_rs.pyi
@@ -1,0 +1,118 @@
+"""Type stub for the compiled `bioregion_rs` PyO3 extension.
+
+Hand-maintained: PyO3/maturin extensions don't auto-generate stubs. Keep this
+in sync with each `#[pyfunction]` in `src/**/*.rs` -- `pyo3_polars::PyDataFrame`
+arguments/returns are plain `polars.DataFrame` at the Python boundary.
+"""
+
+import polars as pl
+
+def darken_hex_color(hex_color: str, factor: float = 0.5) -> str: ...
+def select_geocode(df: pl.DataFrame, precision: int) -> pl.DataFrame: ...
+def with_geocode(df: pl.DataFrame, precision: int) -> pl.DataFrame: ...
+def filter_by_bounding_box(
+    df: pl.DataFrame,
+    min_lat: float,
+    max_lat: float,
+    min_lng: float,
+    max_lng: float,
+    lat_col: str = "decimalLatitude",
+    lng_col: str = "decimalLongitude",
+) -> pl.DataFrame: ...
+def build_geocode(
+    df: pl.DataFrame,
+    precision: int,
+    min_lat: float,
+    max_lat: float,
+    min_lng: float,
+    max_lng: float,
+) -> pl.DataFrame: ...
+def build_taxonomy(
+    darwin_core_df: pl.DataFrame,
+    geocode_precision: int,
+    geocode_df: pl.DataFrame,
+    min_lat: float,
+    max_lat: float,
+    min_lng: float,
+    max_lng: float,
+) -> pl.DataFrame: ...
+def build_geocode_taxa_counts(
+    darwin_core_df: pl.DataFrame,
+    geocode_precision: int,
+    taxonomy_df: pl.DataFrame,
+    geocode_df: pl.DataFrame,
+    min_lat: float,
+    max_lat: float,
+    min_lng: float,
+    max_lng: float,
+) -> pl.DataFrame: ...
+def build_geocode_neighbors(geocode_df: pl.DataFrame) -> pl.DataFrame: ...
+def build_geocode_neighbors_no_edges(
+    geocode_neighbors_df: pl.DataFrame,
+    geocode_no_edges_df: pl.DataFrame,
+) -> pl.DataFrame: ...
+def build_geocode_connectivity_matrix(
+    geocode_neighbors_df: pl.DataFrame,
+) -> list[list[int]]: ...
+def build_cluster_taxa_statistics(
+    geocode_taxa_counts_df: pl.DataFrame,
+    geocode_cluster_df: pl.DataFrame,
+    taxonomy_df: pl.DataFrame,
+) -> pl.DataFrame: ...
+def build_cluster_neighbors(
+    geocode_neighbors_df: pl.DataFrame,
+    geocode_cluster_df: pl.DataFrame,
+) -> pl.DataFrame: ...
+def build_cluster_distance_matrix(
+    cluster_taxa_stats_df: pl.DataFrame,
+) -> tuple[list[float], list[int]]: ...
+def build_cluster_color(cluster_neighbors_df: pl.DataFrame) -> pl.DataFrame: ...
+def build_cluster_boundary(
+    geocode_cluster_df: pl.DataFrame,
+    geocode_df: pl.DataFrame,
+) -> pl.DataFrame: ...
+def build_cluster_significant_differences(
+    all_stats: pl.DataFrame,
+    cluster_neighbors: pl.DataFrame,
+) -> pl.DataFrame: ...
+def build_permanova_results(
+    condensed: list[float],
+    geocode_ids: list[int],
+    geocode_cluster_df: pl.DataFrame,
+    permutations: int = 999,
+) -> pl.DataFrame: ...
+def build_geocode_cluster_metrics(
+    condensed: list[float],
+    geocode_cluster_df: pl.DataFrame,
+    weight_silhouette: float = 0.4,
+    weight_calinski_harabasz: float = 0.3,
+    weight_davies_bouldin: float = 0.3,
+) -> pl.DataFrame: ...
+def select_optimal_k_elbow(
+    num_clusters: list[int],
+    inertia: list[float],
+    sensitivity: float = 1.0,
+) -> int | None: ...
+def build_geocode_silhouette_score(
+    condensed: list[float],
+    geocode_cluster_df: pl.DataFrame,
+) -> pl.DataFrame: ...
+def optimize_num_clusters(
+    condensed: list[float],
+    geocode_cluster_df: pl.DataFrame,
+    elbow_sensitivity: float = 1.0,
+    weight_silhouette: float = 0.4,
+    weight_calinski_harabasz: float = 0.3,
+    weight_davies_bouldin: float = 0.3,
+) -> tuple[int, pl.DataFrame]: ...
+def build_geojson_feature_collection(
+    cluster_boundary_df: pl.DataFrame,
+    cluster_colors_df: pl.DataFrame,
+) -> str: ...
+def build_json_output(
+    cluster_significant_differences_df: pl.DataFrame,
+    cluster_boundary_df: pl.DataFrame,
+    taxonomy_df: pl.DataFrame,
+    cluster_color_df: pl.DataFrame,
+    significant_taxa_images_df: pl.DataFrame,
+) -> str: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13,<3.14"
 dependencies = [
     "altair>=6.0.0",
+    "bioregion-rs",
     "black>=25.1.0",
     "dataframely>=1.7.6",
     "folium>=0.19.5",
@@ -51,3 +52,9 @@ exclude = [
 dev = [
     "maturin>=1.14.1",
 ]
+
+[tool.uv.workspace]
+members = ["bioregion_rs"]
+
+[tool.uv.sources]
+bioregion-rs = { workspace = true }

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,12 @@ version = 1
 revision = 3
 requires-python = "==3.13.*"
 
+[manifest]
+members = [
+    "bioregion-rs",
+    "inaturalist-ecoregions",
+]
+
 [[package]]
 name = "altair"
 version = "6.0.0"
@@ -76,6 +82,10 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/71/f7167a0926994a4fd4740befcf379ded751efe7b53c8b790fd581df0c1a2/biom_format-2.1.17-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d17ff0d09c2d58d111756b7fcf05f6709ccc9db511b534d1a636bda58caa39ed", size = 12296610, upload-time = "2025-08-26T15:19:05.797Z" },
     { url = "https://files.pythonhosted.org/packages/6b/06/dbc9e5ee8a413b07cddde794a34ae57b3edd7469934d77fe79c05abf446e/biom_format-2.1.17-cp313-cp313-win_amd64.whl", hash = "sha256:e70c4939545ca65ed0a665ee4b33ded6c1ffa933a9ed1a01990496179f0a29cd", size = 11878888, upload-time = "2025-08-26T15:19:07.523Z" },
 ]
+
+[[package]]
+name = "bioregion-rs"
+source = { editable = "bioregion_rs" }
 
 [[package]]
 name = "black"
@@ -360,6 +370,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "altair" },
+    { name = "bioregion-rs" },
     { name = "black" },
     { name = "dataframely" },
     { name = "folium" },
@@ -395,6 +406,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "altair", specifier = ">=6.0.0" },
+    { name = "bioregion-rs", editable = "bioregion_rs" },
     { name = "black", specifier = ">=25.1.0" },
     { name = "dataframely", specifier = ">=1.7.6" },
     { name = "folium", specifier = ">=0.19.5" },


### PR DESCRIPTION
## Summary
- `bioregion_rs` is now a real `uv` workspace dependency of the root project (declared as `bioregion-rs` in `dependencies`, `[tool.uv.workspace]`/`[tool.uv.sources]` point at it) instead of only being built via a standalone `maturin develop` step in its own CI job. This is a prerequisite for any `src/*.py` code to actually `import bioregion_rs` — nothing does yet, this PR is packaging/CI only.
- `run.yml` and `unittest.yml` previously never built the Rust extension at all; both now install a Rust toolchain and cache cargo artifacts before their `uv run` steps.
- Added a hand-maintained `bioregion_rs/bioregion_rs.pyi` stub (PyO3/maturin extensions don't auto-generate type stubs) so pyright can typecheck call sites once they exist. Verified maturin bundles it into the wheel automatically (lands as `__init__.pyi` + a `py.typed` marker in the installed package) and pyright resolves types from it correctly.
- `bioregion-rs.yml`'s explicit `uv run maturin develop --manifest-path ...` step is now redundant (any `uv run` builds it via the workspace dependency) and was simplified to `uv sync`.
- **Found and worked around a real footgun**: `bioregion_rs/target/wheels/` can hold a stale pre-built wheel that maturin's PEP 517 build backend reuses without reinvoking `cargo`, if that directory persists across builds — reproduced locally (a `touch` on a `.rs` file wasn't enough to force a rebuild once a stale wheel already existed there; had to `rm -rf` it once). Not reachable in CI (every job starts from a clean checkout), but all three workflows' cache steps now deliberately exclude `bioregion_rs/target/wheels` from what gets cached, so this can't creep in later.

## Test plan
- [x] `uv sync` — confirms `bioregion-rs` resolves as a workspace member; `uv run python -c "import bioregion_rs"` succeeds with the full function set
- [x] `uv run pyright .` — 0 errors (stub resolves correctly, verified against a throwaway call site)
- [x] `uv run python bioregion_rs/harness.py` — all checks still pass
- [x] `uv run python -m unittest` — 78 tests pass
- [x] `uv run marimo export html notebook.py -- --no-stop --parquet-source-path=test/sample-archive/ ...` (matching `run.yml`'s `local-archive` args) — full pipeline runs end-to-end, produces `frontend/aggregations.json`

https://claude.ai/code/session_01XefuZ41iibHEgQrxWiqDjg