### PR TITLE
Cut src/dataframes/taxonomy.py's build_taxonomy_lf over to bioregion_rs

### DIFF
--- a/src/dataframes/taxonomy.py
+++ b/src/dataframes/taxonomy.py
@@ -44,8 +44,8 @@ def build_taxonomy_lf(
         "decimalLongitude",
         "scientificName",
         "taxonKey",
-    ).collect()
-    geocode_df = geocode_lf.select("geocode").collect()
+    ).collect(engine="streaming")
+    geocode_df = geocode_lf.select("geocode").collect(engine="streaming")
 
     df = bioregion_rs.build_taxonomy(
         darwin_core_df,

--- a/src/dataframes/taxonomy.py
+++ b/src/dataframes/taxonomy.py
@@ -1,11 +1,10 @@
 import logging
 
 import dataframely as dy
-import polars as pl
 
+import bioregion_rs
 from src.dataframes.darwin_core import DarwinCoreSchema
 from src.dataframes.geocode import GeocodeNoEdgesSchema
-from src.geocode import filter_by_bounding_box, with_geocode_lf
 from src.types import Bbox
 
 logger = logging.getLogger(__name__)
@@ -40,29 +39,21 @@ def build_taxonomy_lf(
     """
     logger.info("build_taxonomy_lf: Starting")
 
-    # Use semi-join to filter without materializing geocodes to Python list
-    geocode_filter_lf = geocode_lf.select("geocode")
+    darwin_core_df = darwin_core_lf.select(
+        "decimalLatitude",
+        "decimalLongitude",
+        "scientificName",
+        "taxonKey",
+    ).collect()
+    geocode_df = geocode_lf.select("geocode").collect()
 
-    lf = (
-        darwin_core_lf.select(
-            "decimalLatitude",
-            "decimalLongitude",
-            "scientificName",
-            pl.col("taxonKey").alias("gbifTaxonId"),
-        )
-        .pipe(filter_by_bounding_box, bounding_box=bounding_box)
-        .pipe(with_geocode_lf, geocode_precision=geocode_precision)
-        .drop(
-            "decimalLatitude",
-            "decimalLongitude",
-        )
-        # Semi-join: keeps rows where geocode exists, without loading list to memory
-        .join(geocode_filter_lf, on="geocode", how="semi")
-        .drop("geocode")
-        .unique()
-        # Add a unique taxonId for each row
-        .with_row_index("taxonId")
-        .cast({"taxonId": pl.UInt32})
+    df = bioregion_rs.build_taxonomy(
+        darwin_core_df,
+        geocode_precision,
+        geocode_df,
+        bounding_box.min_lat,
+        bounding_box.max_lat,
+        bounding_box.min_lng,
+        bounding_box.max_lng,
     )
-
-    return TaxonomySchema.validate(lf, eager=False)
+    return TaxonomySchema.validate(df.lazy(), eager=False)


### PR DESCRIPTION
## Summary
- Phase B.2 of the pipeline-cutover plan: `build_taxonomy_lf` now delegates the bounding-box filter + geocode + semi-join-to-known-geocodes + dedup + synthetic `taxonId` assignment to `bioregion_rs.build_taxonomy`, instead of the hand-rolled lazy polars pipeline.
- Signature and `dataframely`-validated return type (`dy.LazyFrame[TaxonomySchema]`) are unchanged.
- Row order (and thus which literal `taxonId` a pair gets) isn't guaranteed to match Python's old `.unique()` ordering — only the `(scientificName, gbifTaxonId)` pair set and the `taxonId` bijection are guaranteed, which is all downstream code actually relies on (documented in the Rust source already).

## Test plan
- [x] `uv run python -m unittest` — full suite, 78/78 pass (no dedicated test file for this module; leaning on the full suite + harness + pipeline run, per the cutover plan's note that this file has no direct test coverage)
- [x] `uv run pyright .` — 0 errors
- [x] `uv run python bioregion_rs/harness.py` — all checks pass
- [x] `uv run marimo export html notebook.py -- --no-stop --parquet-source-path=test/sample-archive/ ...` — full pipeline runs end-to-end through export

https://claude.ai/code/session_01XefuZ41iibHEgQrxWiqDjg