### PR TITLE
Cut src/matrices/geocode_connectivity.py's GeocodeConnectivityMatrix.build over to bioregion_rs

### DIFF
--- a/src/matrices/geocode_connectivity.py
+++ b/src/matrices/geocode_connectivity.py
@@ -1,9 +1,9 @@
 import logging
 
 import dataframely as dy
-import networkx as nx
 import numpy as np
 
+import bioregion_rs
 from src.dataframes.geocode_neighbors import GeocodeNeighborsSchema
 
 logger = logging.getLogger(__name__)
@@ -27,33 +27,7 @@ class GeocodeConnectivityMatrix:
         Returns:
             GeocodeConnectivityMatrix with spatial adjacency constraints
         """
-        num_geocodes = len(geocode_neighbors_df)
-        connectivity_matrix = np.zeros((num_geocodes, num_geocodes), dtype=int)
-
-        # Build geocode to index mapping
-        geocode_to_index = {
-            geocode: i for i, geocode in enumerate(geocode_neighbors_df["geocode"])
-        }
-
-        for i, neighbors in enumerate(
-            geocode_neighbors_df["direct_and_indirect_neighbors"]
-        ):
-            for neighbor in neighbors:
-                j = geocode_to_index.get(neighbor)
-                if j is not None:
-                    connectivity_matrix[i, j] = 1
-
-        assert_one_connected_component(connectivity_matrix)
-
-        return cls(connectivity_matrix)
-
-
-def assert_one_connected_component(connectivity_matrix: np.ndarray):
-    assert (
-        nx.number_connected_components(
-            nx.from_numpy_array(
-                connectivity_matrix,
-            )
+        connectivity_matrix = np.array(
+            bioregion_rs.build_geocode_connectivity_matrix(geocode_neighbors_df)
         )
-        == 1
-    )
+        return cls(connectivity_matrix)


### PR DESCRIPTION
## Summary
- Phase B.5 of the pipeline-cutover plan: `GeocodeConnectivityMatrix.build()` now delegates the adjacency-matrix construction to `bioregion_rs.build_geocode_connectivity_matrix`, wrapping its `Vec<Vec<i64>>` result as a numpy array. Public API (`._connectivity_matrix`, downstream callers) is unchanged.
- Removed the Python-side `assert_one_connected_component` check: reading the Rust source (`bioregion_rs/src/matrices/geocode_connectivity.rs`'s `is_single_connected_component`) confirmed it already performs the identical single-connected-component check internally and raises before returning, so the Python assert was unreachable dead code, not an independent safeguard — removed rather than left as redundant validation.

## Test plan
- [x] `uv run python -m unittest` — full suite, 78/78 pass (no dedicated test file for this module — leaning on the full suite + harness + pipeline run, per the cutover plan)
- [x] `uv run pyright .` — 0 errors
- [x] `uv run python bioregion_rs/harness.py` — all checks pass
- [x] `uv run marimo export html notebook.py -- --no-stop --parquet-source-path=test/sample-archive/ ...` — full pipeline runs end-to-end through export (exit 0)

https://claude.ai/code/session_01XefuZ41iibHEgQrxWiqDjg