### PR TITLE
Cut cluster_taxa_statistics.py and cluster_neighbors.py over to bioregion_rs

### DIFF
--- a/src/dataframes/cluster_neighbors.py
+++ b/src/dataframes/cluster_neighbors.py
@@ -2,9 +2,9 @@ import logging
 
 import dataframely as dy
 import networkx as nx
-import polars as pl
 
-from src.dataframes.geocode_cluster import GeocodeClusterSchema, cluster_for_geocode
+import bioregion_rs
+from src.dataframes.geocode_cluster import GeocodeClusterSchema
 from src.dataframes.geocode_neighbors import GeocodeNeighborsSchema
 
 logger = logging.getLogger(__name__)
@@ -34,58 +34,11 @@ def build_cluster_neighbors_df(
     """
     logger.info("build_cluster_neighbors_df: Starting")
 
-    # Get unique clusters
-    unique_clusters = geocode_cluster_df["cluster"].unique()
-
-    # Initialize a dictionary to store the direct and indirect neighbors
-    direct_neighbors_map: dict[int, set[int]] = {
-        cluster: set() for cluster in unique_clusters
-    }
-    all_neighbors_map: dict[int, set[int]] = {
-        cluster: set() for cluster in unique_clusters
-    }
-
-    # For each geocode, find neighbors in different clusters
-    for (
-        geocode,
-        direct_neighbors,
-        direct_and_indirect_neighbors,
-    ) in geocode_neighbors_df.select(
-        "geocode", "direct_neighbors", "direct_and_indirect_neighbors"
-    ).iter_rows(named=False):
-        # Get the cluster of the current geocode
-        current_cluster = cluster_for_geocode(geocode_cluster_df, geocode)
-
-        # For each direct neighbor, check if it's in a different cluster
-        for neighbor in direct_neighbors:
-            neighbor_cluster = cluster_for_geocode(geocode_cluster_df, neighbor)
-
-            # If clusters are different, add to direct neighbors
-            if current_cluster != neighbor_cluster:
-                direct_neighbors_map[current_cluster].add(neighbor_cluster)
-                all_neighbors_map[current_cluster].add(neighbor_cluster)
-
-        # For each indirect neighbor, check if it's in a different cluster
-        for neighbor in direct_and_indirect_neighbors:
-            neighbor_cluster = cluster_for_geocode(geocode_cluster_df, neighbor)
-
-            # If clusters are different, add to all neighbors
-            if current_cluster != neighbor_cluster:
-                all_neighbors_map[current_cluster].add(neighbor_cluster)
-
-    df = pl.DataFrame(
-        [
-            {
-                "cluster": cluster,
-                "direct_neighbors": list(direct_neighbors_map[cluster]),
-                "direct_and_indirect_neighbors": list(all_neighbors_map[cluster]),
-            }
-            for cluster in unique_clusters
-        ]
-    ).with_columns(
-        pl.col("cluster").cast(pl.UInt32),
-        pl.col("direct_neighbors").cast(pl.List(pl.UInt32)),
-        pl.col("direct_and_indirect_neighbors").cast(pl.List(pl.UInt32)),
+    df = bioregion_rs.build_cluster_neighbors(
+        geocode_neighbors_df.select(
+            "geocode", "direct_neighbors", "direct_and_indirect_neighbors"
+        ),
+        geocode_cluster_df.select("geocode", "cluster"),
     )
     return ClusterNeighborsSchema.validate(df)
 

--- a/src/dataframes/cluster_taxa_statistics.py
+++ b/src/dataframes/cluster_taxa_statistics.py
@@ -1,9 +1,8 @@
 import logging
-from typing import Optional
 
 import dataframely as dy
-import polars as pl
 
+import bioregion_rs
 from src.dataframes.geocode_cluster import GeocodeClusterSchema
 from src.dataframes.geocode_taxa_counts import GeocodeTaxaCountsSchema
 from src.dataframes.taxonomy import TaxonomySchema
@@ -50,7 +49,9 @@ def build_cluster_taxa_statistics_df(
         f"{taxa_counts_geocodes} unique geocodes, {taxa_counts_taxa} unique taxa"
     )
 
-    cluster_df = geocode_cluster_lf.collect(engine="streaming")
+    cluster_df = geocode_cluster_lf.select("geocode", "cluster").collect(
+        engine="streaming"
+    )
     cluster_geocodes = cluster_df.select("geocode").unique().height
     cluster_clusters = cluster_df.select("cluster").unique().height
     logger.info(
@@ -58,64 +59,11 @@ def build_cluster_taxa_statistics_df(
         f"{cluster_geocodes} unique geocodes, {cluster_clusters} unique clusters"
     )
 
-    df = pl.DataFrame()
+    taxonomy_df = taxonomy_lf.select("taxonId").collect(engine="streaming")
 
-    # First, join the geocode_taxa_counts with taxonomy to get back the taxonomic info
-    joined = geocode_taxa_counts_lf.join(taxonomy_lf, on="taxonId").collect(
-        engine="streaming"
+    df = bioregion_rs.build_cluster_taxa_statistics(
+        taxa_counts_df, cluster_df, taxonomy_df
     )
-
-    logger.info(
-        f"build_cluster_taxa_statistics_df: After joining with taxonomy: {joined.height} rows"
-    )
-
-    # Total count of all observations
-    total_count = joined["count"].sum()
-
-    # Calculate stats for all clusters
-    df.vstack(
-        joined.group_by(["taxonId"])
-        .agg(
-            pl.col("count").sum().alias("count"),
-            (pl.col("count").sum() / total_count).alias("average"),
-        )
-        .pipe(add_cluster_column, value=None)
-        .select(ClusterTaxaStatisticsSchema.columns().keys()),  # Reorder columns
-        in_place=True,
-    )
-
-    # Create a mapping from geocode to cluster
-    geocode_to_cluster = geocode_cluster_lf.select(["geocode", "cluster"])
-
-    # Join the cluster information with the data
-    joined_with_cluster = joined.lazy().join(
-        geocode_to_cluster, on="geocode", how="inner"
-    )
-
-    # Calculate total counts per cluster
-    cluster_totals = joined_with_cluster.group_by("cluster").agg(
-        pl.col("count").sum().alias("total_count_in_cluster")
-    )
-
-    # Calculate stats for each cluster in one operation
-    cluster_stats = (
-        joined_with_cluster.group_by(["cluster", "taxonId"])
-        .agg(
-            pl.col("count").sum().alias("count"),
-        )
-        .join(cluster_totals, on="cluster")
-        .with_columns(
-            [(pl.col("count") / pl.col("total_count_in_cluster")).alias("average")]
-        )
-        .drop("total_count_in_cluster")
-        .select(
-            ClusterTaxaStatisticsSchema.columns().keys()
-        )  # Ensure columns are in the right order
-        .collect(engine="streaming")
-    )
-
-    # Add cluster-specific stats to the dataframe
-    df.vstack(cluster_stats, in_place=True)
 
     logger.info(f"build_cluster_taxa_statistics_df: Final output has {df.height} rows")
 
@@ -126,7 +74,3 @@ def iter_cluster_ids(
     cluster_taxa_statistics_df: dy.DataFrame[ClusterTaxaStatisticsSchema],
 ) -> list[ClusterId]:
     return cluster_taxa_statistics_df["cluster"].unique().to_list()
-
-
-def add_cluster_column(df: pl.DataFrame, value: Optional[int]) -> pl.DataFrame:
-    return df.with_columns(cluster=pl.lit(value).cast(pl.UInt32()))


### PR DESCRIPTION
## Summary
- Phase B.6 of the pipeline-cutover plan:
  - `build_cluster_taxa_statistics_df` now delegates the taxonomy-filter + overall/per-cluster count aggregation to `bioregion_rs.build_cluster_taxa_statistics`. Removed `add_cluster_column`, now dead code with no remaining callers or test coverage.
  - `build_cluster_neighbors_df` now delegates the geocode-to-cluster adjacency derivation to `bioregion_rs.build_cluster_neighbors`, replacing the per-row `cluster_for_geocode` lookup loop. `cluster_for_geocode` itself stays in `geocode_cluster.py` (still used by `src/plot/cluster_taxa.py`).
- Signatures and `dataframely`-validated return types are unchanged in both files.

## Test plan
- [x] `uv run python -m unittest test.test_cluster_taxa_statistics test.test_cluster_color test.test_cluster_significant_differences` — 6/6 pass (no dedicated test file for `cluster_neighbors.py`'s build function itself; these exercise it indirectly via fixtures)
- [x] `uv run python -m unittest` — full suite, 78/78 pass
- [x] `uv run pyright .` — 0 errors
- [x] `uv run python bioregion_rs/harness.py` — all checks pass
- [x] `uv run marimo export html notebook.py -- --no-stop --parquet-source-path=test/sample-archive/ ...` — full pipeline runs end-to-end through export (exit 0)

https://claude.ai/code/session_01XefuZ41iibHEgQrxWiqDjg