### PR TITLE
Cut src/matrices/cluster_distance.py's ClusterDistanceMatrix.build over to bioregion_rs

### DIFF
--- a/src/matrices/cluster_distance.py
+++ b/src/matrices/cluster_distance.py
@@ -1,12 +1,13 @@
-import os
 import numpy as np
 import polars as pl
 from typing import Tuple, List
 from sklearn.preprocessing import RobustScaler
-from scipy.spatial.distance import pdist, squareform
+from scipy.spatial.distance import squareform
 from src.dataframes.cluster_taxa_statistics import ClusterTaxaStatisticsSchema
 import dataframely as dy
-from src.logging import log_action, logger
+
+import bioregion_rs
+from src.logging import log_action
 
 
 def pivot_taxon_counts_for_clusters(
@@ -86,21 +87,10 @@ class ClusterDistanceMatrix:
         cls,
         cluster_taxa_stats: dy.DataFrame[ClusterTaxaStatisticsSchema],
     ) -> "ClusterDistanceMatrix":
-        X, cluster_ids = build_X(cluster_taxa_stats)
-
-        logger.info(
-            f"Building cluster distance matrix: {X.shape[0]} clusters, {X.shape[1]} taxon IDs"
+        condensed, cluster_ids = bioregion_rs.build_cluster_distance_matrix(
+            cluster_taxa_stats
         )
-
-        Y = log_action(
-            f"Running pdist on cluster matrix",
-            lambda: pdist(X, metric="braycurtis"),
-        )
-
-        # Replace any infinity values with 1.0 (maximum distance)
-        Y = np.nan_to_num(Y, nan=1.0, posinf=1.0, neginf=1.0)
-
-        return cls(Y, cluster_ids)
+        return cls(np.array(condensed), list(cluster_ids))
 
     def condensed(self) -> np.ndarray:
         return self._condensed


### PR DESCRIPTION
## Summary
- Phase B.7 of the pipeline-cutover plan: `ClusterDistanceMatrix.build()` now delegates the pivot + `RobustScaler` + Bray-Curtis `pdist` computation to `bioregion_rs.build_cluster_distance_matrix`, which returns `(condensed, cluster_ids)` directly.
- `pivot_taxon_counts_for_clusters`, `build_X`, and `scale_values` are kept as-is (not removed): `.build()` no longer calls them, but `test/test_cluster_distance.py` imports and exercises `pivot_taxon_counts_for_clusters`/`build_X` directly.
- Public API (`condensed()`/`squareform()`/`cluster_ids()`/`get_distance()`/`get_most_similar_clusters()`) is unchanged.

## Test plan
- [x] `uv run python -m unittest test.test_cluster_distance` — 4/4 pass (includes `test_cluster_distance_matrix_build`, which exercises `.build()` end-to-end)
- [x] `uv run python -m unittest` — full suite, 78/78 pass
- [x] `uv run pyright .` — 0 errors
- [x] `uv run python bioregion_rs/harness.py` — all checks pass
- [x] `uv run marimo export html notebook.py -- --no-stop --parquet-source-path=test/sample-archive/ ...` — full pipeline runs end-to-end through export (exit 0)

https://claude.ai/code/session_01XefuZ41iibHEgQrxWiqDjg