### PR TITLE
Cut geocode_silhouette_score.py over to bioregion_rs and wire it into notebook.py

### DIFF
--- a/notebook.py
+++ b/notebook.py
@@ -1063,31 +1063,15 @@ def _(mo):
 
 @app.cell
 def _(all_clusters_df, geocode_distance_matrix, optimal_num_clusters, pl):
-    from sklearn.metrics import silhouette_samples
-
-    from src.dataframes.geocode_silhouette_score import GeocodeSilhouetteScoreSchema
+    from src.dataframes.geocode_silhouette_score import (
+        build_geocode_silhouette_score_df,
+    )
 
     # Get clustering for optimal k
     k_df = all_clusters_df.filter(pl.col("num_clusters") == optimal_num_clusters)
 
-    # Compute per-geocode silhouette scores for the optimal k
-    samples = silhouette_samples(
-        X=geocode_distance_matrix.squareform(),
-        labels=k_df["cluster"],
-        metric="precomputed",
-    )
-
-    geocode_silhouette_score_df = GeocodeSilhouetteScoreSchema.validate(
-        pl.DataFrame(
-            {
-                "geocode": k_df["geocode"],
-                "silhouette_score": list(samples),  # type: ignore
-                "num_clusters": [optimal_num_clusters] * len(k_df),
-            }
-        ).with_columns(
-            pl.col("geocode").cast(pl.UInt64),
-            pl.col("num_clusters").cast(pl.UInt32),
-        )
+    geocode_silhouette_score_df = build_geocode_silhouette_score_df(
+        geocode_distance_matrix, k_df
     )
     return (geocode_silhouette_score_df,)
 

--- a/src/dataframes/geocode_silhouette_score.py
+++ b/src/dataframes/geocode_silhouette_score.py
@@ -1,7 +1,6 @@
 import dataframely as dy
-import polars as pl
-from sklearn.metrics import silhouette_samples, silhouette_score  # type: ignore
 
+import bioregion_rs
 from src.dataframes.geocode_cluster import GeocodeClusterMultiKSchema
 from src.matrices.geocode_distance import GeocodeDistanceMatrix
 
@@ -25,51 +24,7 @@ def build_geocode_silhouette_score_df(
     Returns:
         DataFrame with silhouette scores for all k values tested
     """
-    all_results = []
-
-    # Get unique k values from the geocode_cluster_df
-    k_values = geocode_cluster_df["num_clusters"].unique().sort()
-
-    for k in k_values:
-        # Filter to just this k value
-        k_df = geocode_cluster_df.filter(pl.col("num_clusters") == k)
-
-        geocodes: list[int | None] = []
-        silhouette_scores: list[float] = []
-
-        # The first entry will be for all geocodes, with cluster=null
-        geocodes.append(None)
-        silhouette_scores.append(
-            float(
-                silhouette_score(
-                    X=distance_matrix.squareform(),
-                    labels=k_df["cluster"],
-                    metric="precomputed",
-                )
-            )
-        )
-
-        # Add the clusters and their scores
-        geocodes.extend(k_df["geocode"])
-        samples = silhouette_samples(
-            X=distance_matrix.squareform(),
-            labels=k_df["cluster"],
-            metric="precomputed",
-        )
-        silhouette_scores.extend(list(samples))  # type: ignore
-
-        k_result = pl.DataFrame(
-            {
-                "geocode": geocodes,
-                "silhouette_score": silhouette_scores,
-                "num_clusters": [k] * len(geocodes),
-            }
-        ).with_columns(
-            pl.col("geocode").cast(pl.UInt64, strict=False),
-            pl.col("num_clusters").cast(pl.UInt32),
-        )
-
-        all_results.append(k_result)
-
-    df = pl.concat(all_results)
+    df = bioregion_rs.build_geocode_silhouette_score(
+        distance_matrix.condensed().tolist(), geocode_cluster_df
+    )
     return GeocodeSilhouetteScoreSchema.validate(df)


### PR DESCRIPTION
## Summary
- Phase B.10 of the pipeline-cutover plan: `build_geocode_silhouette_score_df` now delegates the per-geocode silhouette computation to `bioregion_rs.build_geocode_silhouette_score` instead of `sklearn.metrics.silhouette_score`/`silhouette_samples`.
- `notebook.py`'s "GeocodeSilhouetteScore" cell previously **duplicated this same computation inline** via sklearn rather than calling this module at all — `build_geocode_silhouette_score_df` was dead code from the pipeline's perspective, only exercised by its own test and the Rust harness. It now calls `build_geocode_silhouette_score_df` directly, which both lands this cutover in the real pipeline and removes the duplicated logic.
- Signature and `dataframely`-validated return type are unchanged.

## Test plan
- [x] `uv run python -m unittest test.test_geocode_silhouette_score` — 4/4 pass
- [x] `uv run python -m unittest` — full suite, 78/78 pass
- [x] `uv run pyright .` — 0 errors
- [x] `uv run marimo check notebook.py` — 1 pre-existing unrelated warning (a commented-out cell), no new issues
- [x] `uv run python bioregion_rs/harness.py` — all checks pass
- [x] `uv run marimo export html notebook.py -- --no-stop --parquet-source-path=test/sample-archive/ ...` — full pipeline runs end-to-end through export (exit 0), now actually exercising `build_geocode_silhouette_score_df` for the first time

https://claude.ai/code/session_01XefuZ41iibHEgQrxWiqDjg