### PR TITLE
Cut src/geojson.py's build_geojson_feature_collection over to bioregion_rs

### DIFF
--- a/src/geojson.py
+++ b/src/geojson.py
@@ -1,49 +1,20 @@
 import dataframely as dy
-import shapely
 
+import bioregion_rs
 import geojson
 from src import output
 from src.dataframes.cluster_boundary import ClusterBoundarySchema
 from src.dataframes.cluster_color import ClusterColorSchema
-from src.types import ClusterId, Geocode
-
-
-def build_geojson_feature(
-    geometry: shapely.Geometry,
-    cluster: ClusterId,
-    color: str,
-    darkened_color: str,
-) -> geojson.Feature:
-    return geojson.Feature(
-        properties={
-            "color": darkened_color,
-            "fillColor": color,
-            "fillOpacity": 0.7,
-            "weight": 1,
-            "cluster": cluster,
-        },
-        geometry=shapely.geometry.mapping(geometry),  # type: ignore
-    )
 
 
 def build_geojson_feature_collection(
     cluster_boundary_df: dy.DataFrame[ClusterBoundarySchema],
     cluster_colors_df: dy.DataFrame[ClusterColorSchema],
 ) -> geojson.FeatureCollection:
-    features: list[geojson.Feature] = []
-
-    for cluster, boundary, color, darkened_color in cluster_boundary_df.join(
-        cluster_colors_df, on="cluster"
-    ).iter_rows():
-        features.append(
-            build_geojson_feature(
-                shapely.from_wkb(boundary),
-                cluster,
-                color,
-                darkened_color,
-            )
-        )
-    return geojson.FeatureCollection(features)
+    rust_json = bioregion_rs.build_geojson_feature_collection(
+        cluster_boundary_df, cluster_colors_df
+    )
+    return geojson.loads(rust_json)
 
 
 def write_geojson(


### PR DESCRIPTION
## Summary
- Phase B.11 of the pipeline-cutover plan: `build_geojson_feature_collection` now delegates `FeatureCollection` construction to `bioregion_rs.build_geojson_feature_collection`, parsing its returned JSON string back into a `geojson.FeatureCollection` via `geojson.loads()` to preserve the existing return type contract for `write_geojson` and the notebook's folium display cell.
- Removed `build_geojson_feature`, now dead code with no remaining callers or test coverage.
- `write_geojson` (a plain file write) is untouched — I/O, not compute.
- Signature and return type are unchanged.

## Test plan
- [x] `uv run python -m unittest test.test_geojson test.test_cluster_geojson_features` — 3/3 pass
- [x] `uv run python -m unittest` — full suite, 78/78 pass
- [x] `uv run pyright .` — 0 errors
- [x] `uv run python bioregion_rs/harness.py` — all checks pass
- [x] `uv run marimo export html notebook.py -- --no-stop --parquet-source-path=test/sample-archive/ ...` — full pipeline runs end-to-end (exit 0), confirmed `output/output.geojson` is written correctly (folium map + write_geojson both consume the `geojson.loads()`-parsed FeatureCollection successfully)

https://claude.ai/code/session_01XefuZ41iibHEgQrxWiqDjg