### PR TITLE
Cut src/output.py's write_json_output over to bioregion_rs

### DIFF
--- a/src/output.py
+++ b/src/output.py
@@ -6,15 +6,13 @@ to ensure consistent output file handling across the project. It also includes
 functionality for writing JSON output files.
 """
 
-import json
 import logging
 import os
 from typing import Optional
 
 import dataframely as dy
-import polars as pl
-import shapely
 
+import bioregion_rs
 from src.dataframes.cluster_boundary import ClusterBoundarySchema
 from src.dataframes.cluster_color import ClusterColorSchema
 from src.dataframes.cluster_significant_differences import (
@@ -103,14 +101,6 @@ def prepare_file_path(path: str) -> str:
     return path
 
 
-def _wkb_to_geojson(wkb: bytes) -> dict:
-    """
-    Convert WKB geometry to a GeoJSON-compatible dictionary.
-    """
-    geom = shapely.from_wkb(wkb)
-    return json.loads(shapely.to_geojson(geom))
-
-
 def write_json_output(
     cluster_significant_differences_df: dy.DataFrame[
         ClusterSignificantDifferencesSchema
@@ -132,50 +122,15 @@ def write_json_output(
         significant_taxa_images_df: DataFrame with image URLs for significant taxa.
         output_path: The path to write the JSON file to.
     """
-    output_data = []
+    json_str = bioregion_rs.build_json_output(
+        cluster_significant_differences_df,
+        cluster_boundary_df,
+        taxonomy_df,
+        cluster_color_df,
+        significant_taxa_images_df,
+    )
 
-    cluster_data_df = cluster_boundary_df.join(cluster_color_df, on="cluster")
-
-    for row in cluster_data_df.iter_rows(named=True):
-        cluster_id = row["cluster"]
-        boundary_wkb = row["geometry"]
-        color = row["color"]
-        darkened_color = row["darkened_color"]
-
-        significant_taxa_df = (
-            cluster_significant_differences_df.filter(pl.col("cluster") == cluster_id)
-            .join(taxonomy_df, on="taxonId")
-            .join(significant_taxa_images_df, on="taxonId", how="left")
-        )
-
-        significant_taxa = []
-        for r in significant_taxa_df.iter_rows(named=True):
-            significant_taxa.append(
-                {
-                    "scientific_name": r["scientificName"],
-                    "gbif_taxon_id": r["gbifTaxonId"],
-                    "taxon_id": r["taxonId"],
-                    "log2_fold_change": r["log2_fold_change"],
-                    "cluster_count": r["cluster_count"],
-                    "neighbor_count": r["neighbor_count"],
-                    "high_log2_high_count_score": r["high_log2_high_count_score"],
-                    "low_log2_high_count_score": r["low_log2_high_count_score"],
-                    "image_url": r["image_url"],
-                }
-            )
-
-        output_data.append(
-            {
-                "cluster": cluster_id,
-                "boundary": _wkb_to_geojson(boundary_wkb),
-                "significant_taxa": significant_taxa,
-                "color": color,
-                "darkened_color": darkened_color,
-            }
-        )
-
-    # Prepare the output file path
     output_file = prepare_file_path(output_path)
 
     with open(output_file, "w") as json_writer:
-        json.dump(output_data, json_writer, indent=2)
+        json_writer.write(json_str)


### PR DESCRIPTION
## Summary
- Phase B.12 (final file) of the pipeline-cutover plan: `write_json_output` now writes `bioregion_rs.build_json_output`'s returned JSON string directly to file, instead of building `output_data` row by row and calling `json.dump`.
- Removed `_wkb_to_geojson`, now dead code with no remaining callers or test coverage (`test/test_output.py` only exercises the path-management helpers, not `write_json_output`).
- This is the last file in the pipeline-cutover plan — every `src/*.py` function with a `bioregion_rs` counterpart now delegates to it.
- Signature and behavior (writes a JSON file to `output_path`) are unchanged; formatting differs slightly from the old `json.dump(indent=2)` output, which doesn't matter since the frontend only needs valid JSON.

## Test plan
- [x] `uv run python -m unittest test.test_output` — 6/6 pass
- [x] `uv run python -m unittest` — full suite, 78/78 pass
- [x] `uv run pyright .` — 0 errors
- [x] `uv run python bioregion_rs/harness.py` — all checks pass
- [x] `uv run marimo export html notebook.py -- --no-stop --parquet-source-path=test/sample-archive/ ...` — full pipeline runs end-to-end (exit 0); confirmed `frontend/aggregations.json` is written and is valid, well-formed JSON (5 clusters, each with `boundary`/`cluster`/`color`/`darkened_color`/`significant_taxa` keys)

https://claude.ai/code/session_01XefuZ41iibHEgQrxWiqDjg