### PR TITLE
Port connectivity-constrained Ward clustering to Rust and cut it over

### DIFF
--- a/RUST_MIGRATION_PLAN.md
+++ b/RUST_MIGRATION_PLAN.md
@@ -11,12 +11,15 @@ interop question: **can we pass DataFrames/LazyFrames across the Rust↔Python b
   2. **The parquet cache boundary you already have.** `cache_parquet()` already sinks
      every pipeline stage to parquet and rescans it. That is a ready-made seam: a Rust
      stage and a Python stage interoperate just by reading/writing the same parquet file.
-- **A 100% rewrite is not the right target.** Two ML kernels have no faithful Rust
-  equivalent today: **UMAP** (`umap-learn`) and **connectivity-constrained Ward
-  agglomerative clustering** (`sklearn`). Everything else — geometry, H3, graph coloring,
-  group-bys, Fisher's exact, PERMANOVA, cluster metrics, GeoJSON/JSON output — ports
-  cleanly. Recommendation: a **hybrid** where Rust owns the deterministic compute and
-  Python keeps notebook orchestration, all plotting, and (initially) the two hard kernels.
+- **A 100% rewrite is not the right target.** One ML kernel has no faithful Rust
+  equivalent today: **UMAP** (`umap-learn`). The other hard kernel —
+  **connectivity-constrained Ward agglomerative clustering** (`sklearn`) — turned out
+  to have no library equivalent but *was* portable by reproducing sklearn's own
+  `ward_tree` + `_hc_cut` algorithm directly, and is now cut over (see Phase 3).
+  Everything else — geometry, H3, graph coloring, group-bys, Fisher's exact, PERMANOVA,
+  cluster metrics, GeoJSON/JSON output — ports cleanly. Recommendation: a **hybrid**
+  where Rust owns the deterministic compute and Python keeps notebook orchestration,
+  all plotting, and (for now) UMAP.
 - Migrate **file-by-file behind the parquet boundary**, diffing Rust output against the
   current Python output at each stage before switching over.
 
@@ -132,7 +135,7 @@ in-process to skip intermediate parquet I/O.
 | `RobustScaler` | feature scaling | port (median/IQR) | easy |
 | `pdist(braycurtis)` / `squareform` | distance matrix | port (simple loops) | easy |
 | **`umap-learn`** | dim reduction (2 places) | **no faithful equiv** (`annembed` is close-ish) | **hard / keep in Python** |
-| **sklearn `AgglomerativeClustering` ward+connectivity** | clustering | **no equiv** (`kodama` = ward but no connectivity) | **hard / port or keep** |
+| **sklearn `AgglomerativeClustering` ward+connectivity** | clustering | **ported** — reproduce sklearn's `ward_tree`+`_hc_cut` (no crate does connectivity-constrained Ward) | done (was: hard) |
 | `sklearn.manifold.MDS` | taxonomic color layout | port SMACOF, or keep | hard-ish |
 | `matplotlib`/`seaborn`/`altair`/`folium` | plots & maps | **keep in Python** | n/a |
 | `marimo` | notebook orchestration | **keep in Python** (thin driver) | n/a |
@@ -571,11 +574,30 @@ the crate, verified via `harness.py`, available for a future attempt at this.
     the reduced-feature parquet to Rust). `annembed` exists but won't reproduce sklearn/UMAP
     output — a swap here changes clustering results and needs its own validation.
 - `src/dataframes/geocode_cluster.py` — **connectivity-constrained Ward agglomerative
-  clustering** per k. 🔴 `kodama` does Ward but **not** connectivity constraints; sklearn's
-  `ward_tree` with a connectivity graph would need a direct port (feasible — it's a
-  heap-based nearest-merge over the connectivity structure — but it's the single most
-  involved algorithm here). Keep in Python first; port behind the parquet boundary and diff
-  labels against Python before switching.
+  clustering** per k. ✅ DONE and ✅ **cut over** (Phase 4-style, in
+  `dataframes/geocode_cluster.rs`: `build_geocode_cluster_multi_k`). `kodama` does Ward
+  but **not** connectivity constraints, and no other crate does either, so this
+  reproduces sklearn's own algorithm read straight from source:
+  `sklearn.cluster._agglomerative.ward_tree` (the connectivity-constrained heap-based
+  nearest-merge) + `_hc_cut` (cutting the full tree at each k) + the `compute_ward_dist`
+  and `_get_parents` Cython helpers. Two properties made an *exact* deterministic port
+  possible: (1) the pipeline passes the squareform distance matrix as `X` with the
+  default `metric="euclidean"` (not `precomputed`), so each row is a feature vector —
+  the same pre-existing methodology `geocode_cluster_metrics.rs` already preserves; and
+  (2) sklearn's merge heap is keyed on `(inertia, row, col)` with every pair distinct,
+  a strict total order with no ties, so the merge sequence is uniquely determined and a
+  plain Rust `BinaryHeap` reproduces `heapq`'s pop order bit-for-bit. The one
+  heap-array-order-sensitive step (`_hc_cut`'s label numbering) reimplements CPython
+  `heapq`'s sift operations exactly, so the port reproduces sklearn's integer cluster
+  labels, not merely an equivalent partition. Building the full tree **once** and cutting
+  at every k (`compute_full_tree` is always true here — k is far below
+  `max(100, 0.02·n_samples)`) also replaces the Python loop's per-k re-fit. Verified in
+  `harness.py` against sklearn `AgglomerativeClustering(linkage="ward",
+  connectivity=...)` on a connected 4×5 grid graph with *integer* coordinates
+  (deliberately tie-heavy, to stress the merge tie-breaking): cluster labels match
+  **exactly** for every k in 2..6. UMAP still runs in Python and produces the distance
+  matrix this stage consumes — the boundary is `distance_matrix.condensed()`, a clean
+  handoff.
 - `src/dataframes/cluster_color.py` **(taxonomic path)** — UMAP(`metric="precomputed"`) +
   HSV mapping, and `MDS` usage. 🔴 depends on UMAP/MDS. The **geographic** default path is
   already Rust-ready (Phase 2); only migrate taxonomic coloring after UMAP is resolved.
@@ -595,8 +617,7 @@ the crate, verified via `harness.py`, available for a future attempt at this.
 ┌────────────────────────── Python ──────────────────────────┐
 │  marimo notebook (CLI, orchestration, report)               │
 │  plotting: matplotlib / seaborn / altair / folium           │
-│  hard ML kernels: UMAP, Ward+connectivity clustering        │
-│      (until Rust ports are validated)                       │
+│  hard ML kernel: UMAP (no faithful Rust equivalent)         │
 └───────────────▲───────────────────────────▲────────────────┘
                 │ pyo3-polars (frames)       │ parquet cache
                 │ zero-copy in-process       │ (stage boundary)
@@ -605,7 +626,8 @@ the crate, verified via `harness.py`, available for a future attempt at this.
 │  polars · h3o · geo/wkb · petgraph · statrs                 │
 │  darwin_core · geocode · neighbors · taxa_counts ·          │
 │  taxa_statistics · significant_differences · permanova ·    │
-│  cluster_metrics · silhouette · boundaries · colors(geo) ·  │
+│  cluster_metrics · silhouette · ward+connectivity clustering│
+│  boundaries · colors(geo) ·                                 │
 │  connectivity/distance matrices · geojson/json output       │
 └─────────────────────────────────────────────────────────────┘
 ```
@@ -615,7 +637,9 @@ verified correct in isolation; everything except `taxa_counts` and (upstream of 
 `taxonomy` is also cut over into the real pipeline. Those two remain pure Python —
 cutting them over OOM'd the full-GBIF-snapshot CI job, since their value is in Polars'
 lazy engine reducing a huge raw table *before* materializing, which the current
-collect-then-call-Rust boundary can't preserve.
+collect-then-call-Rust boundary can't preserve. UMAP is now the **only** hard ML
+kernel still in Python; the Ward+connectivity clustering it feeds is cut over, taking
+`distance_matrix.condensed()` as its clean handoff boundary.
 
 ## Risks / open questions
 
@@ -625,8 +649,10 @@ collect-then-call-Rust boundary can't preserve.
    parity matters, UMAP likely stays Python permanently. If the pipeline can tolerate a
    different-but-valid embedding, evaluate `annembed` on cluster-quality metrics, not on
    output equality.
-3. **Ward + connectivity clustering** — portable but the most work; port it early behind the
-   parquet diff harness so you can verify label agreement against sklearn before committing.
+3. **Ward + connectivity clustering** — ✅ resolved. Ported by reproducing sklearn's own
+   `ward_tree`+`_hc_cut` (no crate does connectivity-constrained Ward) and cut over; the
+   harness verifies exact label agreement against sklearn, including on a deliberately
+   tie-heavy fixture. This was the most involved single port but is fully deterministic.
 4. **Geometry robustness** — `shapely`/GEOS handle degenerate unions gracefully; pure-Rust
    `geo` boolean ops are improving but for the boundary-union step consider `geos` bindings
    if you hit robustness issues.

--- a/RUST_MIGRATION_PLAN.md
+++ b/RUST_MIGRATION_PLAN.md
@@ -199,24 +199,42 @@ verified against Python in `bioregion_rs/harness.py`.
   the `lazy` feature is currently disabled (Phase 0 finding), so it stays in Python for now.
   (Also confirm the Rust polars build enables the cloud/object-store feature for `gs://`.)
 - `src/dataframes/darwin_core.py` — TODO: schema + bbox filter + column select.
-- `src/dataframes/taxonomy.py` — ✅ DONE: `build_taxonomy` (distinct
+- `src/dataframes/taxonomy.py` — Rust port ✅ exists (`build_taxonomy`: distinct
   (scientificName, gbifTaxonId) pairs restricted to known geocodes, each assigned a
-  synthetic `taxonId`). Uses `DataFrame::group_by`/`unique`/`with_row_index` from
-  **`polars-core`** directly — no `polars-ops`/joins/`is_in` needed (semi-join and
-  dedup done as eager, hand-rolled filters, consistent with the no-`lazy` constraint).
-  Verified against Python by comparing the (scientificName, gbifTaxonId) pair set and
-  that `taxonId` is a 0..n bijection (row order — and thus which literal `taxonId` a
-  pair gets — is not guaranteed to match Python's `.unique()` ordering, only the set
-  and the bijection are).
-- `src/dataframes/geocode_taxa_counts.py` — ✅ DONE: `build_geocode_taxa_counts` (the
-  core `build_geocode_taxa_counts_lf` aggregation; `filter_top_taxa_lf` is deferred —
-  it's an optional scaling filter, not on the critical path). The Python join against
-  taxonomy (on scientificName+gbifTaxonId) and the group-by-sum are hand-rolled with a
-  `HashMap` lookup + `polars-core`'s (deprecated but functional) `GroupBy::sum`, for the
-  same reason as `taxonomy.rs` — no `polars-ops` dependency. Verified by resolving both
-  engines' output back through their own taxonomy to (geocode, scientificName,
-  gbifTaxonId, count) and comparing as sets (sidesteps the taxonId-ordering
-  non-determinism noted above).
+  synthetic `taxonId`; uses `DataFrame::group_by`/`unique`/`with_row_index` from
+  **`polars-core`** directly — no `polars-ops`/joins/`is_in` needed — and is verified
+  correct against Python via `harness.py`), but **🔴 the real pipeline's
+  `build_taxonomy_lf` was NOT cut over to call it** — reverted after 3/3 CI failures on
+  the full GBIF-snapshot job (`gh pr #27`). Root cause: cutting over meant collecting
+  `darwin_core_lf`'s selected columns (including `scientificName`, a string column)
+  into an eager `DataFrame` *before* calling Rust, so Rust could do the bbox-filter +
+  geocode + semi-join + dedup itself. But the *original* Python implementation never
+  collects at all — it stays a `pl.LazyFrame` end to end (`TaxonomySchema.validate(lf,
+  eager=False)`), letting Polars' lazy engine push the semi-join and `.unique()` dedup
+  down *before* materializing anything. Since the real output is one row per distinct
+  species (thousands) but the raw input is one row per occurrence in the bbox
+  (potentially tens of millions for a large snapshot), materializing the *raw* rows
+  before dedup — as the cutover did — is orders of magnitude more memory than
+  materializing the *deduped* result, as the original lazy pipeline does. This OOM'd
+  the CI runner (`gh run view`'s generic "runner lost communication with the server",
+  reproduced 3/3 times, ~56-58min in every time) even though it passed fine against the
+  small `test/sample-archive/` fixture used for local verification — the bug only shows
+  up at real-snapshot scale. **Lesson for any future cutover of this shape:** a
+  "collect the raw input, then reduce inside Rust" boundary only works when the
+  Rust-side reduction is *cheap relative to the raw input size*; when the real value is
+  in reducing cardinality by orders of magnitude (dedup/aggregation over a huge raw
+  table), that reduction has to happen before crossing the Python/Rust boundary, not
+  after — which the current PyO3/`pyo3-polars` interop (whole-`DataFrame`-at-a-time,
+  no chunked/streaming API) can't do without keeping the reduction in lazy Polars.
+- `src/dataframes/geocode_taxa_counts.py` — same status and same root cause as
+  `taxonomy.py` above: Rust port ✅ exists (`build_geocode_taxa_counts`, verified via
+  harness.py; `filter_top_taxa_lf` was always deferred, not on the critical path), but
+  **🔴 `build_geocode_taxa_counts_lf` was NOT cut over** — reverted after 3/3 CI failures
+  on the full GBIF-snapshot job (`gh pr #28`, same "runner lost communication" pattern,
+  ~1h-1h4min elapsed every time). It has the same shape: the real output is aggregated
+  (geocode, taxonId) counts, but the cutover collected raw per-occurrence rows
+  (including `scientificName`) before aggregating in Rust, instead of letting Polars'
+  lazy `group_by` aggregate before materializing.
 - `src/dataframes/geocode_neighbors.py` — ✅ DONE: `build_geocode_neighbors` and
   `build_geocode_neighbors_no_edges` (H3 `grid_ring_fast(1)` for direct adjacency; a
   hand-rolled union-find + brute-force nearest-point search for the connectivity fixup,
@@ -239,14 +257,14 @@ verified against Python in `bioregion_rs/harness.py`.
   `GeocodeConnectivityMatrix.build`'s output for exact matrix equality.
 
 This closes out Phase 1's non-trivial files. `bioregion_rs` now has CI
-(`.github/workflows/bioregion-rs.yml`): `cargo test --lib`, `maturin develop`, and
+(`.github/workflows/bioregion-rs.yml`): `cargo test --lib`, `maturin develop`
+(later: `uv sync`, once it became a workspace dependency — see Phase 4), and
 `harness.py` run on every push, so a Rust change that breaks parity with Python fails
-CI instead of relying on someone running the harness locally. Note this is a
-crate-level check only — the main pipeline's own CI (`run.yml`) still runs the
-all-Python `notebook.py` end-to-end and does not yet invoke `bioregion_rs` at all,
-since no pipeline call site has been switched over to Rust yet (see "Recommended end
-state" above — that cutover is a later step, done file-by-file once each port is
-validated).
+CI instead of relying on someone running the harness locally. At this point in the
+project this was still a crate-level check only — the main pipeline's own CI
+(`run.yml`) ran the all-Python `notebook.py` end-to-end and didn't invoke
+`bioregion_rs` at all, since no pipeline call site had been switched over to Rust yet
+(that cutover work is Phase 4, below).
 
 ### Phase 2 — graph, geometry, and stats (⚠️ ported algorithms)
 
@@ -427,8 +445,10 @@ validated).
   since `cluster_boundary.rs`'s output can be either shape depending on cluster size;
   the refactor also had to change `decode_polygon` to report how many bytes it
   consumed, so a MultiPolygon's embedded per-polygon WKB buffers can be walked in
-  sequence. `write_geojson` (a plain file write) stays in Python — I/O, not compute,
-  and no pipeline call site has been cut over yet. Verified against
+  sequence. `write_geojson` (a plain file write) stays in Python — I/O, not compute.
+  ✅ **Cut over** (Phase 4): `build_geojson_feature_collection` now calls this, parsing
+  the returned JSON string back into a `geojson.FeatureCollection` via `geojson.loads`.
+  Verified against
   `build_geojson_feature_collection` in `harness.py` on real boundaries derived from
   the sample archive (a mix of single-geocode `Polygon` and multi-geocode
   `MultiPolygon` clusters, exercising both shapes): properties compared exactly,
@@ -443,8 +463,9 @@ validated).
   semantics exactly. Boundary WKB is converted to a GeoJSON geometry via the same
   `wkb::decode_geometry` + `geojson` crate path as `geojson.rs`. Returns the
   assembled JSON as a `String` rather than writing it — `prepare_file_path` +
-  the actual file write stay in Python (I/O, not compute; no pipeline call site
-  cut over yet, same rationale as `geojson.rs`'s `write_geojson`). Verified in
+  the actual file write stay in Python (I/O, not compute, same rationale as
+  `geojson.rs`'s `write_geojson`). ✅ **Cut over** (Phase 4): `write_json_output` now
+  writes this string directly to disk instead of building the JSON by hand. Verified in
   `harness.py` against a hand-built fixture (reusing
   `test_build_cluster_significant_differences`'s data) that deliberately
   exercises both join edge cases (a dropped taxonId, a null `image_url`);
@@ -454,6 +475,91 @@ validated).
   confirmed via repo-wide grep that this function is referenced only by its own
   test (`test/test_render.py`), not by `notebook.py` or any other pipeline file.
   Not worth porting unless something starts calling it.
+
+### Phase 4 — pipeline cutover (Rust ports → actually called by `notebook.py`)
+
+Everything above this point was purely additive: `bioregion_rs` functions existed and
+were verified correct against Python via `harness.py`, but nothing in the real
+pipeline (`notebook.py` or any `src/*.py` module) ever imported `bioregion_rs`. This
+phase made the pipeline actually call the Rust implementations, file by file.
+
+**Packaging/CI prerequisite:** `bioregion_rs` was not a runtime dependency of the root
+project at all — it was only built via a standalone `maturin develop` step in its own
+CI job. Made it a `uv` workspace member (root `pyproject.toml`'s
+`[tool.uv.workspace]`/`[tool.uv.sources]`, declared as `bioregion-rs`), added a Rust
+toolchain + cargo cache to `run.yml`/`unittest.yml` (they'd never built the extension
+before), and added a hand-maintained `bioregion_rs/bioregion_rs.pyi` stub so pyright
+can typecheck call sites (PyO3 extensions don't auto-generate stubs; maturin bundles a
+top-level `<module_name>.pyi` into the wheel automatically). Also found and worked
+around a real footgun: `bioregion_rs/target/wheels/` can hold a stale pre-built wheel
+that maturin's build backend reuses without reinvoking `cargo` if that directory
+persists across builds — not reachable in CI (clean checkout every run), but the cache
+steps deliberately exclude that directory to be safe regardless. See
+`bioregion_rs/README.md`'s "Packaging" section for details.
+
+**Cut over** (each function's public signature and `dataframely`-validated return type
+kept identical, so `notebook.py` and every existing test needed zero changes; only the
+function body's internals changed to delegate to `bioregion_rs`):
+`src/dataframes/geocode.py` (`build_geocode_lf`), `src/dataframes/geocode_neighbors.py`
+(both build functions), `src/matrices/geocode_connectivity.py`
+(`GeocodeConnectivityMatrix.build`), `src/dataframes/cluster_taxa_statistics.py`,
+`src/dataframes/cluster_neighbors.py`, `src/matrices/cluster_distance.py`
+(`ClusterDistanceMatrix.build`), `src/dataframes/cluster_color.py` (geographic path
+only), `src/dataframes/cluster_boundary.py`,
+`src/dataframes/cluster_significant_differences.py`,
+`src/dataframes/permanova_results.py`, `src/dataframes/geocode_cluster_metrics.py`
+(`build_geocode_cluster_metrics_df` + `select_optimal_k_elbow`),
+`src/dataframes/geocode_silhouette_score.py` (**plus** wiring `notebook.py`'s
+silhouette cell to actually call it — it was dead code from the pipeline's
+perspective before this, duplicating the same logic inline via sklearn instead),
+`src/geojson.py`, `src/output.py`. `src/cluster_optimization.py` needed no code
+changes — it's pure orchestration over two of the functions above, so it benefited
+automatically once they were individually cut over.
+
+A recurring theme during this phase: several now-Python-side helper functions became
+dead code once their caller's internals moved to Rust (e.g. `add_cluster_column`,
+`to_graph`, `iter_cluster_ids`, `_add_normalized_scores`, `build_geojson_feature`,
+`_wkb_to_geojson`) and were deleted outright, while others stayed even though their
+caller no longer used them internally, because a test file imports and exercises them
+*directly* (e.g. `_reduce_connected_components_to_one`/`_df_to_graph` in
+`geocode_neighbors.py`, `build_X`/`pivot_taxon_counts_for_clusters` in
+`cluster_distance.py`, `_compute_inertia`/`_find_elbow_point` in
+`geocode_cluster_metrics.py`) — those are left as-is, still under direct test, just no
+longer on the hot path.
+
+**Not cut over — reverted after real production failures:**
+`src/dataframes/taxonomy.py` (`build_taxonomy_lf`) and
+`src/dataframes/geocode_taxa_counts.py` (`build_geocode_taxa_counts_lf`). Both Rust
+ports exist and are verified correct via `harness.py`, but wiring them into the real
+pipeline caused the CI `gbif-snapshot` job (the full ~300M-row public GBIF dataset) to
+OOM the runner 3/3 times (GitHub's generic "runner lost communication with the
+server", ~56min-1h4min elapsed every time — never reproduced against the small
+`test/sample-archive/` fixture used for local verification, which is why this wasn't
+caught until real-scale CI). Root cause: both cutovers required collecting
+`darwin_core_lf`'s selected columns (including `scientificName`, a string column) into
+an eager `DataFrame` *before* calling Rust, so Rust could do the
+filter/geocode/join/dedup-or-aggregate itself. But the *original* Python
+implementations never collect early — they stay `pl.LazyFrame` end to end
+(`eager=False`), letting Polars' lazy engine push the semi-join, `.unique()` dedup, and
+`group_by` aggregation down *before* materializing anything. Since the real output for
+both is orders of magnitude smaller than the raw input (one row per distinct species,
+or one row per (geocode, taxonId) pair, vs. one row per raw occurrence — potentially
+tens of millions at full-snapshot scale), materializing the *raw* rows before
+reduction — which is what the cutover did — is orders of magnitude more memory than
+materializing the *reduced* result, which is what the original lazy pipeline does.
+**Lesson for any future cutover of this shape:** a "collect the raw input, then reduce
+inside Rust" boundary only works when the Rust-side reduction is cheap relative to the
+raw input size. When the real value is in reducing cardinality by orders of magnitude
+(dedup/aggregation over a huge raw table), that reduction has to happen *before*
+crossing the Python/Rust boundary — which the current PyO3/`pyo3-polars` interop
+(whole-`DataFrame`-at-a-time, no chunked/streaming API) can't do without keeping the
+reduction itself in lazy Polars. A real fix would mean either giving `bioregion_rs` a
+streaming/chunked ingestion API, or restructuring these two functions so the
+cardinality-reducing step (semi-join + dedup / group-by) happens lazily in Polars
+first and only the cheap remainder (taxonId assignment / final formatting) goes
+through Rust — out of scope for now. `build_taxonomy_lf`/`build_geocode_taxa_counts_lf`
+remain pure Python; `bioregion_rs.build_taxonomy`/`build_geocode_taxa_counts` stay in
+the crate, verified via `harness.py`, available for a future attempt at this.
 
 ### Phase 3 — hard ML kernels (🔴 keep in Python until validated)
 
@@ -503,6 +609,13 @@ validated).
 │  connectivity/distance matrices · geojson/json output       │
 └─────────────────────────────────────────────────────────────┘
 ```
+
+**Status vs. this diagram (see Phase 4 above):** everything listed is ported and
+verified correct in isolation; everything except `taxa_counts` and (upstream of it)
+`taxonomy` is also cut over into the real pipeline. Those two remain pure Python —
+cutting them over OOM'd the full-GBIF-snapshot CI job, since their value is in Polars'
+lazy engine reducing a huge raw table *before* materializing, which the current
+collect-then-call-Rust boundary can't preserve.
 
 ## Risks / open questions
 

--- a/bioregion_rs/bioregion_rs.pyi
+++ b/bioregion_rs/bioregion_rs.pyi
@@ -93,6 +93,14 @@ def select_optimal_k_elbow(
     inertia: list[float],
     sensitivity: float = 1.0,
 ) -> int | None: ...
+def build_geocode_cluster_multi_k(
+    geocodes: list[int],
+    condensed: list[float],
+    edge_a: list[int],
+    edge_b: list[int],
+    min_k: int,
+    max_k: int,
+) -> pl.DataFrame: ...
 def build_geocode_silhouette_score(
     condensed: list[float],
     geocode_cluster_df: pl.DataFrame,

--- a/bioregion_rs/harness.py
+++ b/bioregion_rs/harness.py
@@ -739,6 +739,96 @@ def _six_point_three_pair_fixture():
     return condensed, geocode_cluster_multi_k_df, distance_matrix
 
 
+# --- src/dataframes/geocode_cluster.py ----------------------------------------
+
+
+def _grid_cluster_fixture():
+    """A connected 4x5 spatial grid graph over 20 points with *integer*
+    coordinates. Integer coords make many pairwise distances (hence many ward
+    inertias) exactly equal, which stresses the merge-heap tie-breaking that
+    both sklearn and the Rust port resolve via the (inertia, row, col) key."""
+    from scipy.spatial.distance import pdist
+
+    from src.matrices.geocode_connectivity import GeocodeConnectivityMatrix
+    from src.matrices.geocode_distance import GeocodeDistanceMatrix
+
+    rows, cols = 4, 5
+    n = rows * cols
+    coords = np.array([[float(r), float(c)] for r in range(rows) for c in range(cols)])
+    # scipy pdist order == GeocodeDistanceMatrix.condensed()
+    condensed = pdist(coords)
+    distance_matrix = GeocodeDistanceMatrix(condensed, coords)
+
+    adj = np.zeros((n, n), dtype=np.int64)
+
+    def node(r, c):
+        return r * cols + c
+
+    for r in range(rows):
+        for c in range(cols):
+            if r + 1 < rows:
+                a, b = node(r, c), node(r + 1, c)
+                adj[a, b] = adj[b, a] = 1
+            if c + 1 < cols:
+                a, b = node(r, c), node(r, c + 1)
+                adj[a, b] = adj[b, a] = 1
+    connectivity_matrix = GeocodeConnectivityMatrix(adj)
+    geocodes = pl.Series("geocode", list(range(n)), dtype=pl.UInt64)
+    return geocodes, condensed, distance_matrix, connectivity_matrix
+
+
+def test_build_geocode_cluster_multi_k() -> None:
+    print("src/dataframes/geocode_cluster.py  (build_geocode_cluster_multi_k):")
+    from scipy.sparse import csr_matrix
+    from sklearn.cluster import AgglomerativeClustering
+
+    geocodes, condensed, distance_matrix, connectivity_matrix = _grid_cluster_fixture()
+    n = len(geocodes)
+    min_k, max_k = 2, 6
+
+    edge_rows, edge_cols = np.nonzero(
+        np.triu(connectivity_matrix._connectivity_matrix, k=1)
+    )
+    rust_df = bioregion_rs.build_geocode_cluster_multi_k(
+        geocodes.to_list(),
+        condensed.tolist(),
+        edge_rows.tolist(),
+        edge_cols.tolist(),
+        min_k,
+        max_k,
+    )
+    check(
+        f"non-trivial: {rust_df.height} rows over {max_k - min_k + 1} k values",
+        rust_df.height == n * (max_k - min_k + 1),
+    )
+
+    square = distance_matrix.squareform()
+    all_match = True
+    saw_multi_cluster = False
+    for k in range(min_k, max_k + 1):
+        # Reference: sklearn, exactly as the pre-cutover pipeline called it.
+        ref = AgglomerativeClustering(
+            n_clusters=k,
+            connectivity=csr_matrix(connectivity_matrix._connectivity_matrix),
+            linkage="ward",
+        ).fit_predict(square)
+
+        # geocodes are 0..n-1 in order, so sort("geocode") aligns with ref index.
+        rust_k = (
+            rust_df.filter(pl.col("num_clusters") == k)
+            .sort("geocode")
+            .get_column("cluster")
+            .to_list()
+        )
+        if rust_k != ref.tolist():
+            all_match = False
+        if len(set(ref.tolist())) > 1:
+            saw_multi_cluster = True
+
+    check("cluster labels match sklearn exactly for every k", all_match)
+    check("fixture actually produces multiple clusters", saw_multi_cluster)
+
+
 def test_build_geocode_cluster_metrics() -> None:
     print(
         "src/dataframes/geocode_cluster_metrics.py  (build_geocode_cluster_metrics):"
@@ -1112,6 +1202,7 @@ def main() -> None:
     test_build_cluster_boundary()
     test_build_cluster_significant_differences()
     test_build_permanova_results()
+    test_build_geocode_cluster_multi_k()
     test_build_geocode_cluster_metrics()
     test_build_geocode_silhouette_score()
     test_optimize_num_clusters()

--- a/bioregion_rs/src/dataframes/geocode_cluster.rs
+++ b/bioregion_rs/src/dataframes/geocode_cluster.rs
@@ -1,0 +1,434 @@
+//! Port of `src/dataframes/geocode_cluster.py`'s per-k clustering loop
+//! (`build_geocode_cluster_multi_k_df`).
+//!
+//! The Python code calls, once per `k` in `[min_k, max_k]`:
+//!
+//! ```python
+//! AgglomerativeClustering(
+//!     n_clusters=k,
+//!     connectivity=csr_matrix(connectivity_matrix),
+//!     linkage="ward",
+//! ).fit_predict(distance_matrix.squareform())
+//! ```
+//!
+//! There is no Rust library that does connectivity-constrained Ward
+//! agglomerative clustering, so this reproduces sklearn's own algorithm
+//! exactly, reading straight from its source rather than its docs:
+//! `sklearn.cluster._agglomerative.ward_tree` (the connectivity-constrained
+//! hierarchical merge) and `_hc_cut` (cutting the resulting full tree at `k`
+//! clusters), plus the two Cython helpers `compute_ward_dist` and
+//! `_get_parents` from `_hierarchical_fast.pyx`.
+//!
+//! Two facts about that algorithm make an exact, deterministic port possible:
+//!
+//! 1. Note the Python passes the *squareform distance matrix* as `X` with the
+//!    default `metric="euclidean"` (not `metric="precomputed"`). So Ward treats
+//!    each row of the square distance matrix as an n-dimensional feature vector
+//!    and computes ordinary Euclidean distances between rows — the same
+//!    "unusual but pre-existing" methodology already preserved in
+//!    `geocode_cluster_metrics.rs`. `feature vector for point i` is therefore
+//!    exactly `condensed_dist(.., i, j) for j in 0..n`.
+//! 2. sklearn's merge heap is keyed on the tuple `(inertia, row, col)` where
+//!    every `(row, col)` pair is pushed at most once and every pair is distinct,
+//!    so the key is a *strict total order* with no ties. The merge sequence is
+//!    thus uniquely determined and independent of any heap's internal layout —
+//!    a plain `BinaryHeap` reproduces sklearn's `heapq` pop order bit-for-bit.
+//!
+//! The one place a heap's internal array order is observable is `_hc_cut`'s
+//! final `enumerate(nodes)` (it decides which cluster gets integer label 0, 1,
+//! …), so that step reimplements CPython's `heapq` push/pushpop sift operations
+//! precisely, to reproduce sklearn's cluster-label integers and not merely an
+//! equivalent partition.
+//!
+//! Building the full tree once and cutting it at every `k` (as `compute_full_tree`
+//! does — always true here since `k` is far below `max(100, 0.02 * n_samples)`)
+//! also means we run the O(n^2 * features) merge a single time instead of once
+//! per `k` as the Python loop does.
+
+use std::cmp::{Ordering, Reverse};
+use std::collections::BinaryHeap;
+
+use polars::prelude::*;
+use pyo3::prelude::*;
+use pyo3_polars::PyDataFrame;
+
+use crate::dataframes::geocode_cluster_metrics::condensed_dist;
+use crate::to_py;
+
+/// A candidate merge between clusters `hi` and `lo` (`hi > lo`, matching how
+/// sklearn stores `(coord_row, coord_col)`), ordered ascending by
+/// `(weight, hi, lo)` so a min-heap reproduces `heapq`'s pop order exactly.
+#[derive(Clone, Copy)]
+struct Edge {
+    weight: f64,
+    hi: usize,
+    lo: usize,
+}
+
+impl PartialEq for Edge {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+impl Eq for Edge {}
+impl Ord for Edge {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.weight
+            .total_cmp(&other.weight)
+            .then(self.hi.cmp(&other.hi))
+            .then(self.lo.cmp(&other.lo))
+    }
+}
+impl PartialOrd for Edge {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Ward inertia of merging clusters `row` and `col`, mirroring the arithmetic
+/// (and summation order) of sklearn's Cython `compute_ward_dist`.
+fn ward_dist(m1: &[f64], m2: &[Vec<f64>], row: usize, col: usize) -> f64 {
+    let (mr, mc) = (m1[row], m1[col]);
+    let n = (mr * mc) / (mr + mc);
+    let mut pa = 0.0;
+    let (r2, c2) = (&m2[row], &m2[col]);
+    for f in 0..r2.len() {
+        let d = r2[f] / mr - c2[f] / mc;
+        pa += d * d;
+    }
+    pa * n
+}
+
+/// Build the full connectivity-constrained Ward tree, returning `children`
+/// in sklearn's format: `children[m] == (lower, higher)` are the two nodes
+/// merged to form node `n + m`. `edges` are the undirected connectivity edges
+/// as `(a, b)` index pairs (each edge once; direction irrelevant).
+fn ward_tree(condensed: &[f64], n: usize, edges: &[(usize, usize)]) -> Vec<(usize, usize)> {
+    let n_nodes = 2 * n - 1;
+
+    // moments_1 = cluster sizes (leaves = 1); moments_2 = summed feature rows
+    // (leaf i's features are row i of the squareform distance matrix).
+    let mut m1 = vec![0.0f64; n_nodes];
+    for v in m1.iter_mut().take(n) {
+        *v = 1.0;
+    }
+    let mut m2: Vec<Vec<f64>> = vec![Vec::new(); n_nodes];
+    for (i, slot) in m2.iter_mut().enumerate().take(n) {
+        *slot = (0..n).map(|j| condensed_dist(condensed, n, i, j)).collect();
+    }
+
+    // Adjacency ("structure matrix" A). Symmetric: every edge on both endpoints.
+    let mut adj: Vec<Vec<usize>> = vec![Vec::new(); n_nodes];
+    for &(a, b) in edges {
+        adj[a].push(b);
+        adj[b].push(a);
+    }
+
+    // Seed the heap with one entry per undirected edge, keyed (inertia, hi, lo).
+    let mut heap: BinaryHeap<Reverse<Edge>> = BinaryHeap::new();
+    for &(a, b) in edges {
+        let (lo, hi) = if a < b { (a, b) } else { (b, a) };
+        let weight = ward_dist(&m1, &m2, hi, lo);
+        heap.push(Reverse(Edge { weight, hi, lo }));
+    }
+
+    let mut parent: Vec<usize> = (0..n_nodes).collect();
+    let mut used = vec![true; n_nodes];
+    let mut not_visited = vec![true; n_nodes];
+    let mut children: Vec<(usize, usize)> = Vec::with_capacity(n - 1);
+
+    for k in n..n_nodes {
+        // Pop the cheapest still-valid merge (both endpoints not yet merged).
+        let (i, j) = loop {
+            let Reverse(e) = heap.pop().expect("heap exhausted before tree complete");
+            if used[e.hi] && used[e.lo] {
+                break (e.hi, e.lo);
+            }
+        };
+        parent[i] = k;
+        parent[j] = k;
+        children.push((i, j)); // (hi, lo); reversed to (lo, hi) on return
+        used[i] = false;
+        used[j] = false;
+
+        // Update moments for the new node, then free the two merged rows — they
+        // are never read again (only current roots are ever revisited), which
+        // halves peak feature-row memory versus sklearn's static moments array.
+        m1[k] = m1[i] + m1[j];
+        let row: Vec<f64> = (0..m2[i].len()).map(|f| m2[i][f] + m2[j][f]).collect();
+        m2[i] = Vec::new();
+        m2[j] = Vec::new();
+        m2[k] = row;
+
+        // Recompute the structure matrix: the distinct current roots reachable
+        // from the neighbours of i then j (mirrors `_get_parents` over A[i], A[j]).
+        for v in not_visited.iter_mut() {
+            *v = true;
+        }
+        not_visited[k] = false;
+        let mut coord_col: Vec<usize> = Vec::new();
+        for &start in adj[i].iter().chain(adj[j].iter()) {
+            let mut node = start;
+            while parent[node] != node {
+                node = parent[node];
+            }
+            if not_visited[node] {
+                not_visited[node] = false;
+                coord_col.push(node);
+            }
+        }
+        for &col in &coord_col {
+            adj[col].push(k);
+            let weight = ward_dist(&m1, &m2, k, col);
+            heap.push(Reverse(Edge {
+                weight,
+                hi: k,
+                lo: col,
+            }));
+        }
+        adj[k] = coord_col;
+    }
+
+    children.into_iter().map(|(hi, lo)| (lo, hi)).collect()
+}
+
+// --- CPython `heapq`, reproduced exactly for `_hc_cut` label numbering -------
+//
+// Operates on negated node ids (so the min-heap yields the largest id), matching
+// sklearn's `nodes = [-(...)]` convention. Only the operations `_hc_cut` uses
+// (push, pushpop) are implemented.
+
+fn heap_siftdown(heap: &mut [i64], startpos: usize, mut pos: usize) {
+    let newitem = heap[pos];
+    while pos > startpos {
+        let parentpos = (pos - 1) >> 1;
+        if newitem < heap[parentpos] {
+            heap[pos] = heap[parentpos];
+            pos = parentpos;
+        } else {
+            break;
+        }
+    }
+    heap[pos] = newitem;
+}
+
+fn heap_siftup(heap: &mut [i64], mut pos: usize) {
+    let endpos = heap.len();
+    let startpos = pos;
+    let newitem = heap[pos];
+    let mut childpos = 2 * pos + 1;
+    while childpos < endpos {
+        let rightpos = childpos + 1;
+        if rightpos < endpos && !(heap[childpos] < heap[rightpos]) {
+            childpos = rightpos;
+        }
+        heap[pos] = heap[childpos];
+        pos = childpos;
+        childpos = 2 * pos + 1;
+    }
+    heap[pos] = newitem;
+    heap_siftdown(heap, startpos, pos);
+}
+
+fn heap_push(heap: &mut Vec<i64>, item: i64) {
+    heap.push(item);
+    let last = heap.len() - 1;
+    heap_siftdown(heap, 0, last);
+}
+
+fn heap_pushpop(heap: &mut [i64], mut item: i64) -> i64 {
+    if !heap.is_empty() && heap[0] < item {
+        std::mem::swap(&mut heap[0], &mut item);
+        heap_siftup(heap, 0);
+    }
+    item
+}
+
+/// All leaf (`< n_leaves`) descendants of `node` — mirrors
+/// `_hierarchical._hc_get_descendent` (the leaf set is order-independent).
+fn descendents(node: usize, children: &[(usize, usize)], n_leaves: usize) -> Vec<usize> {
+    if node < n_leaves {
+        return vec![node];
+    }
+    let mut stack = vec![node];
+    let mut out = Vec::new();
+    while let Some(i) = stack.pop() {
+        if i < n_leaves {
+            out.push(i);
+        } else {
+            let (a, b) = children[i - n_leaves];
+            stack.push(a);
+            stack.push(b);
+        }
+    }
+    out
+}
+
+/// Cut the full Ward tree into `k` clusters, returning per-leaf labels.
+/// Reproduces `sklearn.cluster._agglomerative._hc_cut`, including the exact
+/// `heapq` array order that fixes each cluster's integer label.
+fn hc_cut(k: usize, children: &[(usize, usize)], n_leaves: usize) -> Vec<u32> {
+    // Root id == n_leaves + (#merges) - 1; the second-to-last created node is
+    // always a child of the root, so `max(children[-1]) + 1 == root` (see the
+    // sklearn source), which is what this mirrors.
+    let root = n_leaves + children.len() - 1;
+    let mut nodes: Vec<i64> = vec![-(root as i64)];
+    for _ in 0..k.saturating_sub(1) {
+        let node_id = (-nodes[0]) as usize;
+        let (c0, c1) = children[node_id - n_leaves];
+        heap_push(&mut nodes, -(c0 as i64));
+        heap_pushpop(&mut nodes, -(c1 as i64));
+    }
+
+    let mut label = vec![0u32; n_leaves];
+    for (i, &node) in nodes.iter().enumerate() {
+        let head = (-node) as usize;
+        for leaf in descendents(head, children, n_leaves) {
+            label[leaf] = i as u32;
+        }
+    }
+    label
+}
+
+/// Connectivity-constrained Ward clustering for every `k` in `[min_k, max_k]`.
+///
+/// `geocodes` are the row labels of the distance/connectivity matrices (same
+/// order for all three). `condensed` is the scipy `pdist`-order upper triangle
+/// of the squareform distance matrix used as Ward's feature matrix `X`.
+/// `edge_a`/`edge_b` are the connectivity graph's undirected edges as index
+/// pairs into that ordering. Returns one row per (geocode, k) with the cluster
+/// label, matching `GeocodeClusterMultiKSchema`.
+#[pyfunction]
+#[pyo3(signature = (geocodes, condensed, edge_a, edge_b, min_k, max_k))]
+pub fn build_geocode_cluster_multi_k(
+    geocodes: Vec<u64>,
+    condensed: Vec<f64>,
+    edge_a: Vec<usize>,
+    edge_b: Vec<usize>,
+    min_k: usize,
+    max_k: usize,
+) -> PyResult<PyDataFrame> {
+    let n = geocodes.len();
+    let edges: Vec<(usize, usize)> = edge_a
+        .iter()
+        .zip(edge_b.iter())
+        .map(|(&a, &b)| (a, b))
+        .collect();
+
+    let children = ward_tree(&condensed, n, &edges);
+
+    let num_ks = if max_k >= min_k { max_k - min_k + 1 } else { 0 };
+    let total = n * num_ks;
+    let mut geocode_col: Vec<u64> = Vec::with_capacity(total);
+    let mut num_clusters_col: Vec<u32> = Vec::with_capacity(total);
+    let mut cluster_col: Vec<u32> = Vec::with_capacity(total);
+    for k in min_k..=max_k {
+        let labels = hc_cut(k, &children, n);
+        for idx in 0..n {
+            geocode_col.push(geocodes[idx]);
+            num_clusters_col.push(k as u32);
+            cluster_col.push(labels[idx]);
+        }
+    }
+
+    let out = DataFrame::new(
+        total,
+        vec![
+            UInt64Chunked::from_vec("geocode".into(), geocode_col).into_column(),
+            UInt32Chunked::from_vec("num_clusters".into(), num_clusters_col).into_column(),
+            UInt32Chunked::from_vec("cluster".into(), cluster_col).into_column(),
+        ],
+    )
+    .map_err(to_py)?;
+    Ok(PyDataFrame(out))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A tiny path graph 0-1-2-3-4 with distances that make the ends closer to
+    // their inner neighbours; exercises the merge loop and the tree cut.
+    fn path_edges(n: usize) -> Vec<(usize, usize)> {
+        (0..n - 1).map(|i| (i, i + 1)).collect()
+    }
+
+    fn condensed_from_square(sq: &[Vec<f64>]) -> Vec<f64> {
+        let n = sq.len();
+        let mut c = Vec::new();
+        for i in 0..n {
+            for j in (i + 1)..n {
+                c.push(sq[i][j]);
+            }
+        }
+        c
+    }
+
+    #[test]
+    fn full_tree_has_n_minus_1_merges() {
+        let n = 5;
+        // simple metric: |i - j|
+        let sq: Vec<Vec<f64>> = (0..n)
+            .map(|i| (0..n).map(|j| (i as f64 - j as f64).abs()).collect())
+            .collect();
+        let condensed = condensed_from_square(&sq);
+        let children = ward_tree(&condensed, n, &path_edges(n));
+        assert_eq!(children.len(), n - 1);
+        // every child is stored (lower, higher)
+        for &(lo, hi) in &children {
+            assert!(lo < hi);
+        }
+    }
+
+    #[test]
+    fn cut_produces_requested_cluster_count_and_covers_all_leaves() {
+        let n = 6;
+        let sq: Vec<Vec<f64>> = (0..n)
+            .map(|i| (0..n).map(|j| (i as f64 - j as f64).abs()).collect())
+            .collect();
+        let condensed = condensed_from_square(&sq);
+        let children = ward_tree(&condensed, n, &path_edges(n));
+        for k in 2..=4 {
+            let labels = hc_cut(k, &children, n);
+            assert_eq!(labels.len(), n);
+            let distinct: std::collections::HashSet<u32> = labels.iter().copied().collect();
+            assert_eq!(distinct.len(), k, "k={k} should yield k clusters");
+            // labels are a dense 0..k range
+            assert_eq!(
+                distinct,
+                (0..k as u32).collect::<std::collections::HashSet<_>>()
+            );
+        }
+        // On a path graph, contiguous points should cluster together.
+        let labels2 = hc_cut(2, &children, n);
+        // the split of a path into 2 connectivity-constrained ward clusters is
+        // a single cut point: labels form two contiguous runs.
+        let mut changes = 0;
+        for w in labels2.windows(2) {
+            if w[0] != w[1] {
+                changes += 1;
+            }
+        }
+        assert_eq!(changes, 1, "a path split into 2 clusters has one boundary");
+    }
+
+    #[test]
+    fn cpython_heapq_pushpop_matches_reference() {
+        // Reproduce a small sequence and compare against hand-computed heapq order.
+        let mut h: Vec<i64> = Vec::new();
+        for v in [-4, -1, -3, -2, -5] {
+            heap_push(&mut h, v);
+        }
+        // CPython heapq internal array for these pushes:
+        // push -4 -> [-4]
+        // push -1 -> [-4,-1]
+        // push -3 -> [-4,-1,-3]
+        // push -2 -> [-4,-2,-3,-1]
+        // push -5 -> [-5,-4,-3,-1,-2]
+        assert_eq!(h, vec![-5, -4, -3, -1, -2]);
+        let popped = heap_pushpop(&mut h, -6);
+        assert_eq!(popped, -6, "pushpop of a smaller item returns it unchanged");
+        let popped = heap_pushpop(&mut h, 0);
+        assert_eq!(popped, -5, "pushpop of a larger item evicts the min");
+    }
+}

--- a/bioregion_rs/src/dataframes/geocode_cluster_metrics.rs
+++ b/bioregion_rs/src/dataframes/geocode_cluster_metrics.rs
@@ -32,7 +32,7 @@ use crate::to_py;
 
 /// Distance between points `i` and `j` in a scipy `pdist`-order condensed
 /// vector for `n` objects; 0.0 when `i == j`.
-fn condensed_dist(condensed: &[f64], n: usize, i: usize, j: usize) -> f64 {
+pub(crate) fn condensed_dist(condensed: &[f64], n: usize, i: usize, j: usize) -> f64 {
     if i == j {
         return 0.0;
     }

--- a/bioregion_rs/src/dataframes/mod.rs
+++ b/bioregion_rs/src/dataframes/mod.rs
@@ -6,6 +6,7 @@ pub mod cluster_neighbors;
 pub mod cluster_significant_differences;
 pub mod cluster_taxa_statistics;
 pub mod geocode;
+pub mod geocode_cluster;
 pub mod geocode_cluster_metrics;
 pub mod geocode_neighbors;
 pub mod geocode_silhouette_score;

--- a/bioregion_rs/src/lib.rs
+++ b/bioregion_rs/src/lib.rs
@@ -85,6 +85,10 @@ fn bioregion_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
         m
     )?)?;
     m.add_function(wrap_pyfunction!(
+        dataframes::geocode_cluster::build_geocode_cluster_multi_k,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(
         dataframes::geocode_silhouette_score::build_geocode_silhouette_score,
         m
     )?)?;

--- a/src/dataframes/geocode_cluster.py
+++ b/src/dataframes/geocode_cluster.py
@@ -2,10 +2,10 @@ import logging
 from typing import Iterator, List, Tuple
 
 import dataframely as dy
+import numpy as np
 import polars as pl
-from scipy.sparse import csr_matrix
-from sklearn.cluster import AgglomerativeClustering
 
+import bioregion_rs
 from src.dataframes.geocode import GeocodeNoEdgesSchema
 from src.matrices.geocode_connectivity import GeocodeConnectivityMatrix
 from src.matrices.geocode_distance import GeocodeDistanceMatrix
@@ -109,33 +109,22 @@ def build_geocode_cluster_multi_k_df(
         f"Testing {max_k - min_k + 1} cluster configurations (k={min_k} to k={max_k})"
     )
 
-    all_results = []
-
-    for k in range(min_k, max_k + 1):
-        logger.info(f"Testing k={k}...")
-
-        clusters = AgglomerativeClustering(
-            n_clusters=k,
-            connectivity=csr_matrix(connectivity_matrix._connectivity_matrix),  # type: ignore
-            linkage="ward",
-        ).fit_predict(distance_matrix.squareform())
-
-        assert len(geocodes) == len(clusters)
-
-        k_df = pl.DataFrame(
-            data={
-                "geocode": geocodes,
-                "num_clusters": [k] * len(geocodes),
-                "cluster": clusters,
-            }
-        ).with_columns(
-            pl.col("num_clusters").cast(pl.UInt32),
-            pl.col("cluster").cast(pl.UInt32),
-        )
-
-        all_results.append(k_df)
-
-    df = pl.concat(all_results)
+    # Connectivity-constrained Ward agglomerative clustering, delegated to Rust
+    # (bioregion_rs.build_geocode_cluster_multi_k). It reproduces sklearn's
+    # ward_tree + _hc_cut exactly, building the full merge tree once and cutting
+    # it at every k, instead of re-fitting AgglomerativeClustering per k as this
+    # loop used to. The connectivity matrix is a symmetric 0/1 adjacency, so its
+    # strict upper triangle is each undirected edge once; those edge endpoints
+    # index into the same geocode ordering as the (condensed) distance matrix.
+    edge_rows, edge_cols = np.nonzero(np.triu(connectivity_matrix._connectivity_matrix, k=1))
+    df = bioregion_rs.build_geocode_cluster_multi_k(
+        geocodes.to_list(),
+        distance_matrix.condensed().tolist(),
+        edge_rows.tolist(),
+        edge_cols.tolist(),
+        min_k,
+        max_k,
+    )
 
     logger.info(
         f"build_geocode_cluster_multi_k_df: Final output has {df.height} rows "


### PR DESCRIPTION
## What

Ports the last big compute kernel that was still Python-only — **connectivity-constrained Ward agglomerative clustering** — to `bioregion_rs`, and cuts the live pipeline over to it. `src/dataframes/geocode_cluster.py::build_geocode_cluster_multi_k_df` now delegates its per-k `AgglomerativeClustering(linkage="ward", connectivity=...)` loop to `bioregion_rs.build_geocode_cluster_multi_k`.

No Rust crate does connectivity-constrained Ward (`kodama` does Ward but not the connectivity constraint), so `dataframes/geocode_cluster.rs` reproduces sklearn's own algorithm read straight from source: `ward_tree` (heap-based nearest-merge over the connectivity structure), `_hc_cut` (cutting the full tree at each k), and the `compute_ward_dist` / `_get_parents` Cython helpers.

## Why it's an exact, deterministic port

- The pipeline passes the **squareform distance matrix as `X`** with default `metric="euclidean"` (not `precomputed`), so each row is a feature vector — the same pre-existing methodology `geocode_cluster_metrics.rs` already preserves.
- sklearn's merge heap is keyed on `(inertia, row, col)` with every pair distinct — a **strict total order, no ties** — so the merge sequence is uniquely determined and a plain Rust `BinaryHeap` reproduces `heapq`'s pop order bit-for-bit.
- The one heap-array-order-sensitive step (`_hc_cut` label numbering) reimplements CPython `heapq`'s sift operations exactly, so the port reproduces sklearn's **integer cluster labels**, not just an equivalent partition.
- Builds the full tree **once** and cuts at every k, replacing the Python loop's per-k re-fit.

## Verification

- **harness.py**: compares Rust vs `sklearn.AgglomerativeClustering` directly on a connected 4x5 grid graph with integer (tie-heavy) coordinates; labels match exactly for every k in 2..6.
- **End-to-end**: full `test/sample-archive/` pipeline runs clean (optimal k=6).
- `cargo test --lib` (29), `python -m unittest` (78), `pyright` (0 errors) all green.

UMAP is now the only hard ML kernel still in Python. `RUST_MIGRATION_PLAN.md` updated.

https://claude.ai/code/session_01XefuZ41iibHEgQrxWiqDjg