### PR TITLE
Remove dataframely

### DIFF
--- a/notebook.py
+++ b/notebook.py
@@ -410,10 +410,7 @@ def _(bounding_box, limit_results, parquet_source_path, taxon_filter):
 
 @app.cell
 def _(bounding_box, cache_parquet, darwin_core_lf, geocode_precision):
-    from src.dataframes.geocode import (
-        GeocodeSchema,
-        build_geocode_lf,
-    )
+    from src.dataframes.geocode import build_geocode_lf
 
     geocode_lf_with_edges = cache_parquet(
         build_geocode_lf(
@@ -421,32 +418,27 @@ def _(bounding_box, cache_parquet, darwin_core_lf, geocode_precision):
             geocode_precision,
             bounding_box=bounding_box,
         ),
-        cache_key=GeocodeSchema,
+        cache_key="GeocodeSchema",
     )
     return (geocode_lf_with_edges,)
 
 
 @app.cell
 def _(cache_parquet, geocode_lf_with_edges):
-    from src.dataframes.geocode import (
-        GeocodeNoEdgesSchema,
-        build_geocode_no_edges_lf,
-    )
+    from src.dataframes.geocode import build_geocode_no_edges_lf
 
     geocode_unfiltered_lf = cache_parquet(
         build_geocode_no_edges_lf(
             geocode_lf_with_edges,
         ),
-        cache_key=GeocodeNoEdgesSchema,
+        cache_key="GeocodeNoEdgesSchema",
     )
-    return GeocodeNoEdgesSchema, geocode_unfiltered_lf
+    return (geocode_unfiltered_lf,)
 
 
 @app.cell
 def _(geocode_lf_with_edges):
-    from src.dataframes.geocode_neighbors import (
-        build_geocode_neighbors_df,
-    )
+    from src.dataframes.geocode_neighbors import build_geocode_neighbors_df
 
     # Build neighbors for all geocodes (including edges)
     geocode_neighbors_with_edges_df = build_geocode_neighbors_df(
@@ -457,10 +449,7 @@ def _(geocode_lf_with_edges):
 
 @app.cell
 def _(cache_parquet, geocode_lf, geocode_neighbors_with_edges_df):
-    from src.dataframes.geocode_neighbors import (
-        GeocodeNeighborsSchema,
-        build_geocode_neighbors_no_edges_df,
-    )
+    from src.dataframes.geocode_neighbors import build_geocode_neighbors_no_edges_df
 
     # Build neighbors for filtered geocodes only
     geocode_neighbors_df = cache_parquet(
@@ -468,7 +457,7 @@ def _(cache_parquet, geocode_lf, geocode_neighbors_with_edges_df):
             geocode_neighbors_with_edges_df,
             geocode_lf.collect(),
         ),
-        cache_key=GeocodeNeighborsSchema,
+        cache_key="GeocodeNeighborsSchema",
     ).collect()
     return (geocode_neighbors_df,)
 
@@ -511,7 +500,7 @@ def _(
     geocode_precision,
     geocode_unfiltered_lf,
 ):
-    from src.dataframes.taxonomy import TaxonomySchema, build_taxonomy_lf
+    from src.dataframes.taxonomy import build_taxonomy_lf
 
     taxonomy_lf = cache_parquet(
         build_taxonomy_lf(
@@ -520,7 +509,7 @@ def _(
             geocode_unfiltered_lf,
             bounding_box=bounding_box,
         ),
-        cache_key=TaxonomySchema,
+        cache_key="TaxonomySchema",
     )
     return (taxonomy_lf,)
 
@@ -540,10 +529,7 @@ def _(
     geocode_unfiltered_lf,
     taxonomy_lf,
 ):
-    from src.dataframes.geocode_taxa_counts import (
-        GeocodeTaxaCountsSchema,
-        build_geocode_taxa_counts_lf,
-    )
+    from src.dataframes.geocode_taxa_counts import build_geocode_taxa_counts_lf
 
     geocode_taxa_counts_unfiltered_lf = cache_parquet(
         build_geocode_taxa_counts_lf(
@@ -553,16 +539,14 @@ def _(
             geocode_unfiltered_lf,
             bounding_box=bounding_box,
         ),
-        cache_key=GeocodeTaxaCountsSchema,
+        cache_key="GeocodeTaxaCountsSchema",
     )
     return (geocode_taxa_counts_unfiltered_lf,)
 
 
 @app.cell
 def _(geocode_taxa_counts_unfiltered_lf, max_taxa, min_geocode_presence):
-    from src.dataframes.geocode_taxa_counts import (
-        filter_top_taxa_lf,
-    )
+    from src.dataframes.geocode_taxa_counts import filter_top_taxa_lf
 
     # Apply taxa filtering if configured
     geocode_taxa_counts_lf = filter_top_taxa_lf(
@@ -580,16 +564,13 @@ def _(geocode_taxa_counts_lf):
 
 
 @app.cell
-def _(GeocodeNoEdgesSchema, geocode_taxa_counts_lf, geocode_unfiltered_lf, pl):
+def _(geocode_taxa_counts_lf, geocode_unfiltered_lf, pl):
     # Filter geocode_unfiltered_lf to only include geocodes present in geocode_taxa_counts_lf
-    geocode_lf = GeocodeNoEdgesSchema.validate(
-        geocode_unfiltered_lf.join(
+    geocode_lf = geocode_unfiltered_lf.join(
             geocode_taxa_counts_lf.select(pl.col("geocode").unique()),
             on="geocode",
             how="semi",
-        ),
-        eager=False,
-    )
+        )
     return (geocode_lf,)
 
 
@@ -670,10 +651,7 @@ def _(
     max_clusters_to_test,
     min_clusters_to_test,
 ):
-    from src.dataframes.geocode_cluster import (
-        GeocodeClusterMultiKSchema,
-        build_geocode_cluster_multi_k_df,
-    )
+    from src.dataframes.geocode_cluster import build_geocode_cluster_multi_k_df
 
     all_clusters_df = cache_parquet(
         build_geocode_cluster_multi_k_df(
@@ -683,7 +661,7 @@ def _(
             min_k=min_clusters_to_test,
             max_k=max_clusters_to_test,
         ),
-        cache_key=GeocodeClusterMultiKSchema,
+        cache_key="GeocodeClusterMultiKSchema",
     ).collect(engine="streaming")
     return (all_clusters_df,)
 
@@ -715,11 +693,10 @@ def _(
 @app.cell
 def _(all_cluster_metrics, cache_parquet):
     # Cache the results
-    from src.dataframes.geocode_cluster_metrics import GeocodeClusterMetricsSchema
 
     all_cluster_metrics_df = cache_parquet(
         all_cluster_metrics,
-        cache_key=GeocodeClusterMetricsSchema,
+        cache_key="GeocodeClusterMetricsSchema",
     ).collect(engine="streaming")
     return (all_cluster_metrics_df,)
 
@@ -727,17 +704,14 @@ def _(all_cluster_metrics, cache_parquet):
 @app.cell
 def _(all_clusters_df, cache_parquet, optimal_num_clusters):
     # Create base GeocodeClusterSchema (single k) for downstream use
-    from src.dataframes.geocode_cluster import (
-        GeocodeClusterSchema,
-        build_geocode_cluster_df,
-    )
+    from src.dataframes.geocode_cluster import build_geocode_cluster_df
 
     geocode_cluster_df = cache_parquet(
         build_geocode_cluster_df(
             all_clusters_df,
             optimal_num_clusters,
         ),
-        cache_key=GeocodeClusterSchema,
+        cache_key="GeocodeClusterSchema",
     ).collect(engine="streaming")
     return (geocode_cluster_df,)
 
@@ -812,17 +786,14 @@ def _(mo):
 
 @app.cell
 def _(cache_parquet, geocode_cluster_df, geocode_neighbors_df):
-    from src.dataframes.cluster_neighbors import (
-        ClusterNeighborsSchema,
-        build_cluster_neighbors_df,
-    )
+    from src.dataframes.cluster_neighbors import build_cluster_neighbors_df
 
     cluster_neighbors_lf = cache_parquet(
         build_cluster_neighbors_df(
             geocode_neighbors_df,
             geocode_cluster_df,
         ),
-        cache_key=ClusterNeighborsSchema,
+        cache_key="ClusterNeighborsSchema",
     )
     return (cluster_neighbors_lf,)
 
@@ -843,10 +814,7 @@ def _(mo):
 
 @app.cell
 def _(cache_parquet, geocode_cluster_df, geocode_taxa_counts_lf, taxonomy_lf):
-    from src.dataframes.cluster_taxa_statistics import (
-        ClusterTaxaStatisticsSchema,
-        build_cluster_taxa_statistics_df,
-    )
+    from src.dataframes.cluster_taxa_statistics import build_cluster_taxa_statistics_df
 
     cluster_taxa_statistics_df = cache_parquet(
         build_cluster_taxa_statistics_df(
@@ -854,7 +822,7 @@ def _(cache_parquet, geocode_cluster_df, geocode_taxa_counts_lf, taxonomy_lf):
             geocode_cluster_df.lazy(),
             taxonomy_lf,
         ),
-        cache_key=ClusterTaxaStatisticsSchema,
+        cache_key="ClusterTaxaStatisticsSchema",
     ).collect(engine="streaming")
     return (cluster_taxa_statistics_df,)
 
@@ -875,17 +843,14 @@ def _(mo):
 
 @app.cell
 def _(cache_parquet, cluster_neighbors_lf, cluster_taxa_statistics_df):
-    from src.dataframes.cluster_significant_differences import (
-        ClusterSignificantDifferencesSchema,
-        build_cluster_significant_differences_df,
-    )
+    from src.dataframes.cluster_significant_differences import build_cluster_significant_differences_df
 
     cluster_significant_differences_df = cache_parquet(
         build_cluster_significant_differences_df(
             cluster_taxa_statistics_df,
             cluster_neighbors_lf,
         ),
-        cache_key=ClusterSignificantDifferencesSchema,
+        cache_key="ClusterSignificantDifferencesSchema",
     ).collect(engine="streaming")
     return (cluster_significant_differences_df,)
 
@@ -906,17 +871,14 @@ def _(mo):
 
 @app.cell
 def _(cache_parquet, geocode_cluster_df, geocode_lf):
-    from src.dataframes.cluster_boundary import (
-        ClusterBoundarySchema,
-        build_cluster_boundary_df,
-    )
+    from src.dataframes.cluster_boundary import build_cluster_boundary_df
 
     cluster_boundary_df = cache_parquet(
         build_cluster_boundary_df(
             geocode_cluster_df,
             geocode_lf,
         ),
-        cache_key=ClusterBoundarySchema,
+        cache_key="ClusterBoundarySchema",
     ).collect(engine="streaming")
     return (cluster_boundary_df,)
 
@@ -994,7 +956,7 @@ def _(
     cluster_taxa_statistics_df,
     color_method,
 ):
-    from src.dataframes.cluster_color import ClusterColorSchema, build_cluster_color_df
+    from src.dataframes.cluster_color import build_cluster_color_df
 
     cluster_colors_df = cache_parquet(
         build_cluster_color_df(
@@ -1002,7 +964,7 @@ def _(
             cluster_taxa_statistics_df,
             color_method=color_method,
         ),
-        cache_key=ClusterColorSchema,
+        cache_key="ClusterColorSchema",
     ).collect(engine="streaming")
     return (cluster_colors_df,)
 
@@ -1031,10 +993,7 @@ def _(mo):
 
 @app.cell
 def _(cache_parquet, geocode_cluster_df, geocode_distance_matrix, geocode_lf):
-    from src.dataframes.permanova_results import (
-        PermanovaResultsSchema,
-        build_permanova_results_df,
-    )
+    from src.dataframes.permanova_results import build_permanova_results_df
 
     permanova_results_df = cache_parquet(
         build_permanova_results_df(
@@ -1042,7 +1001,7 @@ def _(cache_parquet, geocode_cluster_df, geocode_distance_matrix, geocode_lf):
             geocode_cluster_df=geocode_cluster_df,
             geocode_lf=geocode_lf,
         ),
-        cache_key=PermanovaResultsSchema,
+        cache_key="PermanovaResultsSchema",
     ).collect(engine="streaming")
     return (permanova_results_df,)
 
@@ -1063,9 +1022,7 @@ def _(mo):
 
 @app.cell
 def _(all_clusters_df, geocode_distance_matrix, optimal_num_clusters, pl):
-    from src.dataframes.geocode_silhouette_score import (
-        build_geocode_silhouette_score_df,
-    )
+    from src.dataframes.geocode_silhouette_score import build_geocode_silhouette_score_df
 
     # Get clustering for optimal k
     k_df = all_clusters_df.filter(pl.col("num_clusters") == optimal_num_clusters)
@@ -1234,17 +1191,14 @@ def _(mo):
 
 @app.cell
 def _(cache_parquet, cluster_significant_differences_df, taxonomy_lf):
-    from src.dataframes.significant_taxa_images import (
-        SignificantTaxaImagesSchema,
-        build_significant_taxa_images_df,
-    )
+    from src.dataframes.significant_taxa_images import build_significant_taxa_images_df
 
     significant_taxa_images_df = cache_parquet(
         build_significant_taxa_images_df(
             cluster_significant_differences_df,
             taxonomy_lf.collect(engine="streaming"),
         ),
-        cache_key=SignificantTaxaImagesSchema,
+        cache_key="SignificantTaxaImagesSchema",
     ).collect(engine="streaming")
     return (significant_taxa_images_df,)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
     "altair>=6.0.0",
     "bioregion-rs",
     "black>=25.1.0",
-    "dataframely>=1.7.6",
     "folium>=0.19.5",
     "geojson>=3.1.0",
     "google-auth>=2.43.0",

--- a/src/cache_parquet.py
+++ b/src/cache_parquet.py
@@ -2,40 +2,19 @@ import hashlib
 import logging
 import os
 import tempfile
-from typing import TypeVar, cast, overload
 
-import dataframely as dy
 import polars as pl
 
 logger = logging.getLogger(__name__)
 
 
-SchemaT = TypeVar("SchemaT", bound=dy.Schema)
-
-
-@overload
 def cache_parquet(
-    data: dy.LazyFrame[SchemaT],
-    cache_key: type[dy.Schema],
+    data: pl.LazyFrame | pl.DataFrame,
+    cache_key: str,
     cache_dir: str | None = None,
-) -> dy.LazyFrame[SchemaT]: ...
-
-
-@overload
-def cache_parquet(
-    data: dy.DataFrame[SchemaT],
-    cache_key: type[dy.Schema],
-    cache_dir: str | None = None,
-) -> dy.LazyFrame[SchemaT]: ...
-
-
-def cache_parquet(
-    data: dy.LazyFrame[SchemaT] | dy.DataFrame[SchemaT],
-    cache_key: type[dy.Schema],
-    cache_dir: str | None = None,
-) -> dy.LazyFrame[SchemaT]:
+) -> pl.LazyFrame:
     # Hash the cache key to create a consistent filename
-    cache_hash = hashlib.sha256(cache_key.__name__.encode()).hexdigest()
+    cache_hash = hashlib.sha256(cache_key.encode()).hexdigest()
 
     # Set up cache directory
     if cache_dir is None:
@@ -48,14 +27,10 @@ def cache_parquet(
     output_path = os.path.join(cache_dir, f"{cache_hash}.parquet")
 
     if isinstance(data, pl.LazyFrame):
-        logger.info(
-            f"Writing data from {cache_key.__name__} LazyFrame to {output_path}"
-        )
+        logger.info(f"Writing data from {cache_key} LazyFrame to {output_path}")
         data.sink_parquet(output_path, engine="streaming")
     else:
-        logger.info(
-            f"Writing data from {cache_key.__name__} DataFrame to {output_path}"
-        )
+        logger.info(f"Writing data from {cache_key} DataFrame to {output_path}")
         data.write_parquet(output_path)
 
-    return cast(dy.LazyFrame[SchemaT], pl.scan_parquet(output_path))
+    return pl.scan_parquet(output_path)

--- a/src/cluster_optimization.py
+++ b/src/cluster_optimization.py
@@ -9,12 +9,9 @@ stops providing significant reduction in within-cluster variance (inertia).
 import logging
 from typing import Tuple
 
-import dataframely as dy
 import polars as pl
 
-from src.dataframes.geocode_cluster import GeocodeClusterMultiKSchema
 from src.dataframes.geocode_cluster_metrics import (
-    GeocodeClusterMetricsSchema,
     build_geocode_cluster_metrics_df,
     select_optimal_k_elbow,
 )
@@ -25,9 +22,9 @@ logger = logging.getLogger(__name__)
 
 def optimize_num_clusters(
     distance_matrix: GeocodeDistanceMatrix,
-    geocode_cluster_df: dy.DataFrame[GeocodeClusterMultiKSchema],
+    geocode_cluster_df: pl.DataFrame,
     elbow_sensitivity: float = 1.0,
-) -> Tuple[int, dy.DataFrame[GeocodeClusterMetricsSchema]]:
+) -> Tuple[int, pl.DataFrame]:
     """
     Find optimal number of clusters using the elbow method (Kneedle algorithm).
 

--- a/src/dataframes/cluster_boundary.py
+++ b/src/dataframes/cluster_boundary.py
@@ -1,23 +1,15 @@
+import polars as pl
 import logging
 
-import dataframely as dy
 
 import bioregion_rs
-from src.dataframes.geocode import GeocodeNoEdgesSchema
-from src.dataframes.geocode_cluster import GeocodeClusterSchema
 
 logger = logging.getLogger(__name__)
 
-
-class ClusterBoundarySchema(dy.Schema):
-    cluster = dy.UInt32(nullable=False)
-    geometry = dy.Binary()
-
-
 def build_cluster_boundary_df(
-    geocode_cluster_df: dy.DataFrame[GeocodeClusterSchema],
-    geocode_lf: dy.LazyFrame[GeocodeNoEdgesSchema],
-) -> dy.DataFrame[ClusterBoundarySchema]:
+    geocode_cluster_df: pl.DataFrame,
+    geocode_lf: pl.LazyFrame,
+) -> pl.DataFrame:
     """Build cluster boundaries by combining geocode boundaries.
 
     Creates a single boundary polygon for each cluster by unioning all
@@ -38,4 +30,4 @@ def build_cluster_boundary_df(
 
     logger.info(f"build_cluster_boundary_df: Output has {df.height} cluster boundaries")
 
-    return ClusterBoundarySchema.validate(df)
+    return df

--- a/src/dataframes/cluster_color.py
+++ b/src/dataframes/cluster_color.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Dict, List, Literal, Optional
 
-import dataframely as dy
 import matplotlib.colors as mcolors
 import numpy as np
 import polars as pl
@@ -10,27 +9,18 @@ from sklearn.manifold import MDS  # type: ignore
 
 import bioregion_rs
 from src.colors import darken_hex_color
-from src.dataframes.cluster_neighbors import ClusterNeighborsSchema
-from src.dataframes.cluster_taxa_statistics import ClusterTaxaStatisticsSchema
 from src.matrices.cluster_distance import ClusterDistanceMatrix
 from src.types import ClusterId
 
 logger = logging.getLogger(__name__)
 
-
-class ClusterColorSchema(dy.Schema):
-    cluster = dy.UInt32(nullable=False)
-    color = dy.String(nullable=False)
-    darkened_color = dy.String(nullable=False)
-
-
 def build_cluster_color_df(
-    cluster_neighbors_lf: dy.LazyFrame[ClusterNeighborsSchema],
+    cluster_neighbors_lf: pl.LazyFrame,
     cluster_taxa_statistics_df: Optional[
-        dy.DataFrame[ClusterTaxaStatisticsSchema]
+        pl.DataFrame
     ] = None,
     color_method: Literal["geographic", "taxonomic"] = "geographic",
-) -> dy.DataFrame[ClusterColorSchema]:
+) -> pl.DataFrame:
     """
     Build a ClusterColorSchema DataFrame using either geographic neighbor-based coloring
     or taxonomic similarity-based coloring.
@@ -54,17 +44,17 @@ def build_cluster_color_df(
         df = _build_taxonomic(cluster_taxa_statistics_df)
     else:
         raise ValueError(f"Invalid color_method: {color_method}")
-    return ClusterColorSchema.validate(df)
+    return df
 
 
 def get_color_for_cluster(
-    cluster_color_df: dy.DataFrame[ClusterColorSchema], cluster: ClusterId
+    cluster_color_df: pl.DataFrame, cluster: ClusterId
 ) -> str:
     return cluster_color_df.filter(pl.col("cluster") == cluster)["color"].to_list()[0]
 
 
 def to_dict(
-    cluster_color_df: dy.DataFrame[ClusterColorSchema],
+    cluster_color_df: pl.DataFrame,
 ) -> Dict[ClusterId, str]:
     return {
         x: get_color_for_cluster(cluster_color_df, x)
@@ -73,7 +63,7 @@ def to_dict(
 
 
 def _build_geographic(
-    cluster_neighbors_lf: dy.LazyFrame[ClusterNeighborsSchema],
+    cluster_neighbors_lf: pl.LazyFrame,
 ) -> pl.DataFrame:
     """
     Creates a coloring where neighboring clusters have different colors.
@@ -83,7 +73,7 @@ def _build_geographic(
 
 
 def _build_taxonomic(
-    cluster_taxa_statistics_df: dy.DataFrame[ClusterTaxaStatisticsSchema],
+    cluster_taxa_statistics_df: pl.DataFrame,
 ) -> pl.DataFrame:
     """
     Creates a coloring where clusters with similar taxonomic composition

--- a/src/dataframes/cluster_neighbors.py
+++ b/src/dataframes/cluster_neighbors.py
@@ -1,24 +1,15 @@
+import polars as pl
 import logging
 
-import dataframely as dy
 
 import bioregion_rs
-from src.dataframes.geocode_cluster import GeocodeClusterSchema
-from src.dataframes.geocode_neighbors import GeocodeNeighborsSchema
 
 logger = logging.getLogger(__name__)
 
-
-class ClusterNeighborsSchema(dy.Schema):
-    cluster = dy.UInt32(nullable=False)
-    direct_neighbors = dy.List(dy.UInt32(), nullable=False)
-    direct_and_indirect_neighbors = dy.List(dy.UInt32(), nullable=False)
-
-
 def build_cluster_neighbors_df(
-    geocode_neighbors_df: dy.DataFrame[GeocodeNeighborsSchema],
-    geocode_cluster_df: dy.DataFrame[GeocodeClusterSchema],
-) -> dy.DataFrame[ClusterNeighborsSchema]:
+    geocode_neighbors_df: pl.DataFrame,
+    geocode_cluster_df: pl.DataFrame,
+) -> pl.DataFrame:
     """Build cluster neighbor relationships from geocode neighbor data.
 
     Determines which clusters are neighbors based on the geocode neighbor
@@ -39,4 +30,4 @@ def build_cluster_neighbors_df(
         ),
         geocode_cluster_df.select("geocode", "cluster"),
     )
-    return ClusterNeighborsSchema.validate(df)
+    return df

--- a/src/dataframes/cluster_significant_differences.py
+++ b/src/dataframes/cluster_significant_differences.py
@@ -1,36 +1,15 @@
+import polars as pl
 import logging
 
-import dataframely as dy
 
 import bioregion_rs
-from src.dataframes.cluster_neighbors import ClusterNeighborsSchema
-from src.dataframes.cluster_taxa_statistics import ClusterTaxaStatisticsSchema
 
 logger = logging.getLogger(__name__)
 
-
-class ClusterSignificantDifferencesSchema(dy.Schema):
-    """
-    A dataframe that contains the significant differences between clusters.
-    """
-
-    P_VALUE_THRESHOLD = 0.05
-    MIN_COUNT_THRESHOLD = 5
-
-    cluster = dy.UInt32(nullable=False)
-    taxonId = dy.UInt32(nullable=False)
-    p_value = dy.Float64(nullable=False)
-    log2_fold_change = dy.Float64(nullable=False)
-    cluster_count = dy.UInt32(nullable=False)
-    neighbor_count = dy.UInt32(nullable=False)
-    high_log2_high_count_score = dy.Float64(nullable=False)
-    low_log2_high_count_score = dy.Float64(nullable=False)
-
-
 def build_cluster_significant_differences_df(
-    all_stats: dy.DataFrame[ClusterTaxaStatisticsSchema],
-    cluster_neighbors: dy.LazyFrame[ClusterNeighborsSchema],
-) -> dy.DataFrame[ClusterSignificantDifferencesSchema]:
+    all_stats: pl.DataFrame,
+    cluster_neighbors: pl.LazyFrame,
+) -> pl.DataFrame:
     """Build a ClusterSignificantDifferencesSchema DataFrame.
 
     Identifies taxa that significantly differ between clusters and their neighbors
@@ -55,4 +34,4 @@ def build_cluster_significant_differences_df(
         f"build_cluster_significant_differences_df: Output has {df.height} rows"
     )
 
-    return ClusterSignificantDifferencesSchema.validate(df)
+    return df

--- a/src/dataframes/cluster_taxa_statistics.py
+++ b/src/dataframes/cluster_taxa_statistics.py
@@ -1,29 +1,16 @@
+import polars as pl
 import logging
 
-import dataframely as dy
 
 import bioregion_rs
-from src.dataframes.geocode_cluster import GeocodeClusterSchema
-from src.dataframes.geocode_taxa_counts import GeocodeTaxaCountsSchema
-from src.dataframes.taxonomy import TaxonomySchema
 
 logger = logging.getLogger(__name__)
 
-
-class ClusterTaxaStatisticsSchema(dy.Schema):
-    cluster = dy.UInt32(nullable=True)  # `null` if stats for all clusters
-    taxonId = dy.UInt32(nullable=False)
-    count = dy.UInt32(nullable=False)
-    average = dy.Float64(
-        nullable=False
-    )  # average of taxa with `taxonId` within `cluster`
-
-
 def build_cluster_taxa_statistics_df(
-    geocode_taxa_counts_lf: dy.LazyFrame[GeocodeTaxaCountsSchema],
-    geocode_cluster_lf: dy.LazyFrame[GeocodeClusterSchema],
-    taxonomy_lf: dy.LazyFrame[TaxonomySchema],
-) -> dy.DataFrame[ClusterTaxaStatisticsSchema]:
+    geocode_taxa_counts_lf: pl.LazyFrame,
+    geocode_cluster_lf: pl.LazyFrame,
+    taxonomy_lf: pl.LazyFrame,
+) -> pl.DataFrame:
     """Build cluster taxa statistics from geocode taxa counts.
 
     Computes aggregated statistics (count, average) for each taxon within each cluster,
@@ -66,4 +53,4 @@ def build_cluster_taxa_statistics_df(
 
     logger.info(f"build_cluster_taxa_statistics_df: Final output has {df.height} rows")
 
-    return ClusterTaxaStatisticsSchema.validate(df)
+    return df

--- a/src/dataframes/darwin_core.py
+++ b/src/dataframes/darwin_core.py
@@ -9,7 +9,6 @@ import logging
 from pathlib import Path
 from typing import Union
 
-import dataframely as dy
 import polars as pl
 
 logger = logging.getLogger(__name__)
@@ -18,42 +17,12 @@ from src.darwin_core_utils import build_darwin_core_raw_lf
 from src.geocode import filter_by_bounding_box
 from src.types import Bbox
 
-
-class DarwinCoreSchema(dy.Schema):
-    """Schema for Darwin Core occurrence records.
-
-    This schema defines the core fields needed for bioregionalization analysis
-    from Darwin Core occurrence data. It validates that required geographic
-    and taxonomic fields are present and properly typed.
-    """
-
-    # Geographic fields (required for spatial analysis)
-    decimalLatitude = dy.Float64(nullable=False)
-    decimalLongitude = dy.Float64(nullable=False)
-
-    # Taxonomic metadata
-    scientificName = dy.String(nullable=True)
-    taxonKey = dy.UInt32(nullable=False)
-
-    individualCount = dy.Int32(nullable=True)
-
-    @dy.rule()
-    def valid_latitude(cls) -> pl.Expr:
-        """Validate that latitude is within valid range [-90, 90]."""
-        return pl.col("decimalLatitude").is_between(-90, 90)
-
-    @dy.rule()
-    def valid_longitude(cls) -> pl.Expr:
-        """Validate that longitude is within valid range [-180, 180]."""
-        return pl.col("decimalLongitude").is_between(-180, 180)
-
-
 def build_darwin_core_lf(
     source_path: Union[str, Path],
     bounding_box: Bbox,
     limit: Union[int, None] = None,
     taxon_filter: str = "",
-) -> dy.LazyFrame[DarwinCoreSchema]:
+) -> pl.LazyFrame:
     """Build a validated Darwin Core lazyframe from a source file.
 
     Args:
@@ -87,4 +56,4 @@ def build_darwin_core_lf(
         "individualCount",
     )
 
-    return DarwinCoreSchema.validate(lf, eager=False)
+    return lf

--- a/src/dataframes/geocode.py
+++ b/src/dataframes/geocode.py
@@ -1,44 +1,13 @@
-import dataframely as dy
 import polars as pl
 
 import bioregion_rs
-from src.dataframes.darwin_core import DarwinCoreSchema
 from src.types import Bbox
 
-
-class GeocodeSchema(dy.Schema):
-    """Schema for geocode spatial information.
-
-    Contains H3 hexagon identifiers with their center points, boundaries,
-    and edge status relative to the bounding box.
-    """
-
-    geocode = dy.UInt64(nullable=False)
-    center = dy.Any()  # Binary (geometry)
-    boundary = dy.Any()  # Binary (geometry)
-    # Whether this hexagon is on the edge (intersects bounding box boundary)
-    is_edge = dy.Bool(nullable=False)
-
-
-class GeocodeNoEdgesSchema(GeocodeSchema):
-    """Schema that validates there are no edge hexagons in the dataset.
-
-    This schema inherits all columns and validations from GeocodeSchema
-    and adds an additional rule to ensure that no hexagons intersect
-    the bounding box boundary (i.e., all is_edge values must be False).
-    """
-
-    @dy.rule()
-    def no_edges(cls) -> pl.Expr:
-        """Validate that no hexagons are on the edge of the bounding box."""
-        return ~pl.col("is_edge")
-
-
 def build_geocode_lf(
-    darwin_core_lf: dy.LazyFrame[DarwinCoreSchema],
+    darwin_core_lf: pl.LazyFrame,
     geocode_precision: int,
     bounding_box: Bbox,
-) -> dy.LazyFrame[GeocodeSchema]:
+) -> pl.LazyFrame:
     """Build a GeocodeSchema LazyFrame from Darwin Core occurrence data.
 
     Args:
@@ -60,14 +29,14 @@ def build_geocode_lf(
         bounding_box.min_lng,
         bounding_box.max_lng,
     )
-    return GeocodeSchema.validate(df.lazy(), eager=False)
+    return df.lazy()
 
 
 def build_geocode_df(
-    darwin_core_lf: dy.LazyFrame[DarwinCoreSchema],
+    darwin_core_lf: pl.LazyFrame,
     geocode_precision: int,
     bounding_box: Bbox,
-) -> dy.DataFrame[GeocodeSchema]:
+) -> pl.DataFrame:
     """Build a GeocodeSchema DataFrame from Darwin Core occurrence data.
 
     This is a convenience wrapper around build_geocode_lf() that collects
@@ -82,12 +51,12 @@ def build_geocode_df(
         A validated DataFrame conforming to GeocodeSchema
     """
     lf = build_geocode_lf(darwin_core_lf, geocode_precision, bounding_box)
-    return GeocodeSchema.validate(lf.collect())
+    return lf.collect()
 
 
 def build_geocode_no_edges_lf(
-    geocode_lf: dy.LazyFrame[GeocodeSchema],
-) -> dy.LazyFrame[GeocodeNoEdgesSchema]:
+    geocode_lf: pl.LazyFrame,
+) -> pl.LazyFrame:
     """Build a GeocodeNoEdgesSchema by filtering out edge hexagons from a GeocodeSchema.
 
     This function is fully lazy - no collection occurs until downstream code
@@ -100,12 +69,12 @@ def build_geocode_no_edges_lf(
         A validated GeocodeNoEdgesSchema lazyframe with edge hexagons removed
     """
     lf = geocode_lf.filter(~pl.col("is_edge")).sort(by="geocode")
-    return GeocodeNoEdgesSchema.validate(lf, eager=False)
+    return lf
 
 
 def index_of_geocode(
     geocode: int,
-    geocode_df: dy.DataFrame[GeocodeSchema] | dy.DataFrame[GeocodeNoEdgesSchema],
+    geocode_df: pl.DataFrame | pl.DataFrame,
 ) -> int:
     """Find the index of a geocode in the dataframe.
 

--- a/src/dataframes/geocode_cluster.py
+++ b/src/dataframes/geocode_cluster.py
@@ -1,36 +1,20 @@
 import logging
 from typing import Iterator, List, Tuple
 
-import dataframely as dy
 import numpy as np
 import polars as pl
 
 import bioregion_rs
-from src.dataframes.geocode import GeocodeNoEdgesSchema
 from src.matrices.geocode_connectivity import GeocodeConnectivityMatrix
 from src.matrices.geocode_distance import GeocodeDistanceMatrix
 from src.types import ClusterId, Geocode
 
 logger = logging.getLogger(__name__)
 
-
-class GeocodeClusterSchema(dy.Schema):
-    """Schema for clustering results for a single k value."""
-
-    geocode = dy.UInt64(nullable=False)
-    cluster = dy.UInt32(nullable=False)
-
-
-class GeocodeClusterMultiKSchema(GeocodeClusterSchema):
-    """Schema for clustering results across multiple k values."""
-
-    num_clusters = dy.UInt32(nullable=False)
-
-
 def build_geocode_cluster_df(
-    multi_k_df: dy.DataFrame[GeocodeClusterMultiKSchema],
+    multi_k_df: pl.DataFrame,
     num_clusters: int,
-) -> dy.DataFrame[GeocodeClusterSchema]:
+) -> pl.DataFrame:
     """Extract clustering results for a single k value from multi-k results.
 
     Args:
@@ -55,16 +39,16 @@ def build_geocode_cluster_df(
         f"{unique_geocodes} unique geocodes, {unique_clusters} unique clusters"
     )
 
-    return GeocodeClusterSchema.validate(df)
+    return df
 
 
 def build_geocode_cluster_multi_k_df(
-    geocode_lf: dy.LazyFrame[GeocodeNoEdgesSchema],
+    geocode_lf: pl.LazyFrame,
     distance_matrix: GeocodeDistanceMatrix,
     connectivity_matrix: GeocodeConnectivityMatrix,
     min_k: int,
     max_k: int,
-) -> dy.DataFrame[GeocodeClusterMultiKSchema]:
+) -> pl.DataFrame:
     """Build clustering results for all k values from min_k to max_k.
 
     Args:
@@ -132,17 +116,17 @@ def build_geocode_cluster_multi_k_df(
         f"{df.select('num_clusters').unique().height} k values)"
     )
 
-    return GeocodeClusterMultiKSchema.validate(df)
+    return df
 
 
 def cluster_ids(
-    geocode_cluster_df: dy.DataFrame[GeocodeClusterSchema],
+    geocode_cluster_df: pl.DataFrame,
 ) -> List[ClusterId]:
     return geocode_cluster_df["cluster"].unique().to_list()
 
 
 def iter_clusters_and_geocodes(
-    geocode_cluster_df: dy.DataFrame[GeocodeClusterSchema],
+    geocode_cluster_df: pl.DataFrame,
 ) -> Iterator[Tuple[ClusterId, List[str]]]:
     for row in (geocode_cluster_df.group_by("cluster").all().sort("cluster")).iter_rows(
         named=True
@@ -151,7 +135,7 @@ def iter_clusters_and_geocodes(
 
 
 def cluster_for_geocode(
-    geocode_cluster_df: dy.DataFrame[GeocodeClusterSchema], geocode: Geocode
+    geocode_cluster_df: pl.DataFrame, geocode: Geocode
 ) -> ClusterId:
     return geocode_cluster_df.filter(pl.col("geocode") == geocode)["cluster"].to_list()[
         0
@@ -159,13 +143,13 @@ def cluster_for_geocode(
 
 
 def geocodes_for_cluster(
-    geocode_cluster_df: dy.DataFrame[GeocodeClusterSchema], cluster: ClusterId
+    geocode_cluster_df: pl.DataFrame, cluster: ClusterId
 ) -> List[Geocode]:
     return geocode_cluster_df.filter(pl.col("cluster") == cluster)["geocode"].to_list()
 
 
 def num_clusters(
-    geocode_cluster_df: dy.DataFrame[GeocodeClusterSchema],
+    geocode_cluster_df: pl.DataFrame,
 ) -> int:
     num = geocode_cluster_df["cluster"].max()
     assert isinstance(num, int)

--- a/src/dataframes/geocode_cluster_metrics.py
+++ b/src/dataframes/geocode_cluster_metrics.py
@@ -22,13 +22,11 @@ Using multiple metrics provides more robust k selection than any single metric a
 import logging
 from typing import TypedDict
 
-import dataframely as dy
 import numpy as np
 import polars as pl
 from kneed import KneeLocator  # typed: ignore
 
 import bioregion_rs
-from src.dataframes.geocode_cluster import GeocodeClusterMultiKSchema
 from src.matrices.geocode_distance import GeocodeDistanceMatrix
 
 logger = logging.getLogger(__name__)
@@ -44,34 +42,11 @@ class ElbowAnalysisResult(TypedDict):
     inertia_deltas: list[float]
     inertia_delta2: list[float]
 
-
-class GeocodeClusterMetricsSchema(dy.Schema):
-    """
-    Schema for multi-metric cluster validation results.
-
-    Stores overall cluster quality metrics for each tested k value.
-    All metrics are computed at the clustering level (one row per k).
-    """
-
-    num_clusters = dy.UInt32(nullable=False)
-    silhouette_score = dy.Float64(nullable=False)
-    calinski_harabasz_score = dy.Float64(nullable=False)
-    davies_bouldin_score = dy.Float64(nullable=False)
-    inertia = dy.Float64(nullable=False)
-    # Normalized scores for combining metrics (all scaled to [0, 1])
-    silhouette_normalized = dy.Float64(nullable=False)
-    calinski_harabasz_normalized = dy.Float64(nullable=False)
-    davies_bouldin_normalized = dy.Float64(nullable=False)
-    inertia_normalized = dy.Float64(nullable=False)
-    # Combined score using weighted average of normalized scores
-    combined_score = dy.Float64(nullable=False)
-
-
 def build_geocode_cluster_metrics_df(
     distance_matrix: GeocodeDistanceMatrix,
-    geocode_cluster_df: dy.DataFrame[GeocodeClusterMultiKSchema],
+    geocode_cluster_df: pl.DataFrame,
     weights: dict[str, float] | None = None,
-) -> dy.DataFrame[GeocodeClusterMetricsSchema]:
+) -> pl.DataFrame:
     """
     Build multi-metric cluster validation scores for all clustering results.
 
@@ -123,7 +98,7 @@ def build_geocode_cluster_metrics_df(
         f"{df.sort('combined_score', descending=True)['num_clusters'][0]}"
     )
 
-    return GeocodeClusterMetricsSchema.validate(df)
+    return df
 
 
 def _compute_inertia(dm_square: np.ndarray, labels: np.ndarray) -> float:
@@ -166,7 +141,7 @@ def _compute_inertia(dm_square: np.ndarray, labels: np.ndarray) -> float:
 
 
 def select_optimal_k_elbow(
-    metrics_df: dy.DataFrame[GeocodeClusterMetricsSchema],
+    metrics_df: pl.DataFrame,
     sensitivity: float = 1.0,
 ) -> int | None:
     """
@@ -199,7 +174,7 @@ def select_optimal_k_elbow(
 
 # Backwards compatibility alias
 def select_optimal_k_multi_metric(
-    metrics_df: dy.DataFrame[GeocodeClusterMetricsSchema],
+    metrics_df: pl.DataFrame,
     min_silhouette_threshold: float | None = 0.25,
     selection_method: str = "elbow",
     elbow_sensitivity: float = 1.0,
@@ -231,7 +206,7 @@ def select_optimal_k_multi_metric(
 
 
 def _find_elbow_point(
-    metrics_df: dy.DataFrame[GeocodeClusterMetricsSchema],
+    metrics_df: pl.DataFrame,
     sensitivity: float = 1.0,
 ) -> int | None:
     """
@@ -291,7 +266,7 @@ def _find_elbow_point(
 
 
 def get_elbow_analysis(
-    metrics_df: dy.DataFrame[GeocodeClusterMetricsSchema],
+    metrics_df: pl.DataFrame,
     sensitivity: float = 1.0,
 ) -> ElbowAnalysisResult:
     """
@@ -380,7 +355,7 @@ def get_elbow_analysis(
 
 
 def get_metrics_summary(
-    metrics_df: dy.DataFrame[GeocodeClusterMetricsSchema],
+    metrics_df: pl.DataFrame,
 ) -> pl.DataFrame:
     """
     Format metrics as a summary table for display.

--- a/src/dataframes/geocode_neighbors.py
+++ b/src/dataframes/geocode_neighbors.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Union
 
-import dataframely as dy
 import networkx as nx
 import polars as pl
 import polars_h3
@@ -16,24 +15,9 @@ logger = logging.getLogger(__name__)
 
 MAX_NUM_NEIGHBORS = 6
 
-
-class GeocodeNeighborsSchema(dy.Schema):
-    """Schema for geocode neighbor relationships.
-
-    This schema tracks both direct neighbors (from H3 grid adjacency)
-    and indirect neighbors (added connections to ensure connectivity).
-    """
-
-    geocode = dy.UInt64(nullable=False)
-    # Direct neighbors from H3 grid adjacency
-    direct_neighbors = dy.List(dy.UInt64(), nullable=False)
-    # Direct and indirect neighbors (includes both H3 adjacency and added connections)
-    direct_and_indirect_neighbors = dy.List(dy.UInt64(), nullable=False)
-
-
 def build_geocode_neighbors_df(
     geocode_df: pl.DataFrame,
-) -> dy.DataFrame[GeocodeNeighborsSchema]:
+) -> pl.DataFrame:
     """Build neighbor relationships for geocodes.
 
     Computes direct neighbors using H3 grid adjacency, then adds indirect
@@ -49,13 +33,13 @@ def build_geocode_neighbors_df(
         f"build_geocode_neighbors_df: Building neighbors for {geocode_df.height} geocodes"
     )
     df = bioregion_rs.build_geocode_neighbors(geocode_df.select("geocode", "center"))
-    return GeocodeNeighborsSchema.validate(df)
+    return df
 
 
 def build_geocode_neighbors_no_edges_df(
-    geocode_neighbors_df: dy.DataFrame[GeocodeNeighborsSchema],
+    geocode_neighbors_df: pl.DataFrame,
     geocode_no_edges_df: pl.DataFrame,
-) -> dy.DataFrame[GeocodeNeighborsSchema]:
+) -> pl.DataFrame:
     """Build neighbor relationships for non-edge geocodes.
 
     Filters the neighbor lists to only include valid (non-edge) geocodes,
@@ -75,11 +59,11 @@ def build_geocode_neighbors_no_edges_df(
 
     logger.info(f"GeocodeNeighborsSchema (no edges) contains {len(df)} geocodes")
 
-    return GeocodeNeighborsSchema.validate(df)
+    return df
 
 
 def graph(
-    geocode_neighbors_df: dy.DataFrame[GeocodeNeighborsSchema],
+    geocode_neighbors_df: pl.DataFrame,
     include_indirect_neighbors: bool = False,
 ) -> nx.Graph:
     """Convert geocode neighbors to a NetworkX graph.

--- a/src/dataframes/geocode_silhouette_score.py
+++ b/src/dataframes/geocode_silhouette_score.py
@@ -1,20 +1,12 @@
-import dataframely as dy
 
+import polars as pl
 import bioregion_rs
-from src.dataframes.geocode_cluster import GeocodeClusterMultiKSchema
 from src.matrices.geocode_distance import GeocodeDistanceMatrix
-
-
-class GeocodeSilhouetteScoreSchema(dy.Schema):
-    geocode = dy.UInt64(nullable=True)
-    silhouette_score = dy.Float64(nullable=False)
-    num_clusters = dy.UInt32(nullable=False)
-
 
 def build_geocode_silhouette_score_df(
     distance_matrix: GeocodeDistanceMatrix,
-    geocode_cluster_df: dy.DataFrame[GeocodeClusterMultiKSchema],
-) -> dy.DataFrame[GeocodeSilhouetteScoreSchema]:
+    geocode_cluster_df: pl.DataFrame,
+) -> pl.DataFrame:
     """Build silhouette scores for all clustering results.
 
     Args:
@@ -27,4 +19,4 @@ def build_geocode_silhouette_score_df(
     df = bioregion_rs.build_geocode_silhouette_score(
         distance_matrix.condensed().tolist(), geocode_cluster_df
     )
-    return GeocodeSilhouetteScoreSchema.validate(df)
+    return df

--- a/src/dataframes/geocode_taxa_counts.py
+++ b/src/dataframes/geocode_taxa_counts.py
@@ -1,31 +1,20 @@
 import logging
 
-import dataframely as dy
 import polars as pl
 
-from src.dataframes.darwin_core import DarwinCoreSchema
-from src.dataframes.geocode import GeocodeNoEdgesSchema
-from src.dataframes.taxonomy import TaxonomySchema
 from src.geocode import filter_by_bounding_box, with_geocode_lf
 from src.logging import log_action
 from src.types import Bbox
 
 logger = logging.getLogger(__name__)
 
-
-class GeocodeTaxaCountsSchema(dy.Schema):
-    geocode = dy.UInt64(nullable=False)
-    taxonId = dy.UInt32(nullable=False)
-    count = dy.UInt32(nullable=False)
-
-
 def build_geocode_taxa_counts_lf(
-    darwin_core_lf: dy.LazyFrame[DarwinCoreSchema],
+    darwin_core_lf: pl.LazyFrame,
     geocode_precision: int,
-    taxonomy_lf: dy.LazyFrame[TaxonomySchema],
-    geocode_lf: dy.LazyFrame[GeocodeNoEdgesSchema],
+    taxonomy_lf: pl.LazyFrame,
+    geocode_lf: pl.LazyFrame,
     bounding_box: Bbox,
-) -> dy.LazyFrame[GeocodeTaxaCountsSchema]:
+) -> pl.LazyFrame:
     """Build a GeocodeTaxaCountsSchema DataFrame from Darwin Core data.
 
     Aggregates occurrence counts per geocode and taxon.
@@ -82,12 +71,9 @@ def build_geocode_taxa_counts_lf(
         .sort(by="geocode")
     )
 
-    result_lf = GeocodeTaxaCountsSchema.validate(
-        aggregated.with_columns(
+    result_lf = aggregated.with_columns(
             pl.col("taxonId").cast(pl.UInt32), pl.col("count").cast(pl.UInt32)
-        ),
-        eager=False,
-    )
+        )
 
     # Log output sizes
     result_df = result_lf.collect(engine="streaming")
@@ -102,10 +88,10 @@ def build_geocode_taxa_counts_lf(
 
 
 def filter_top_taxa_lf(
-    geocode_taxa_counts_lf: dy.LazyFrame[GeocodeTaxaCountsSchema],
+    geocode_taxa_counts_lf: pl.LazyFrame,
     max_taxa: int | None = None,
     min_geocode_presence: float | None = None,
-) -> dy.LazyFrame[GeocodeTaxaCountsSchema]:
+) -> pl.LazyFrame:
     """
     Filter to most informative taxa before pivoting.
 
@@ -225,4 +211,4 @@ def filter_top_taxa_lf(
         f"{final_geocodes} unique geocodes, {final_taxa} unique taxa"
     )
 
-    return GeocodeTaxaCountsSchema.validate(lf, eager=False)
+    return lf

--- a/src/dataframes/permanova_results.py
+++ b/src/dataframes/permanova_results.py
@@ -1,34 +1,19 @@
 # src/dataframes/permanova_results.py
+import polars as pl
 import logging
 
-import dataframely as dy
 
 import bioregion_rs
-from src.dataframes.geocode import GeocodeNoEdgesSchema
-from src.dataframes.geocode_cluster import GeocodeClusterSchema
 from src.matrices.geocode_distance import GeocodeDistanceMatrix
 
 logger = logging.getLogger(__name__)
 
-
-class PermanovaResultsSchema(dy.Schema):
-    """
-    Stores the results of a PERMANOVA test.
-    """
-
-    method_name = dy.String(nullable=False)  # e.g., "PERMANOVA"
-    test_statistic_name = dy.String(nullable=False)  # e.g., "pseudo-F"
-    test_statistic = dy.Float64(nullable=False)  # The calculated statistic value
-    p_value = dy.Float64(nullable=False)  # The p-value of the test
-    permutations = dy.UInt64(nullable=False)  # Number of permutations used
-
-
 def build_permanova_results_df(
     geocode_distance_matrix: GeocodeDistanceMatrix,
-    geocode_cluster_df: dy.DataFrame[GeocodeClusterSchema],
-    geocode_lf: dy.LazyFrame[GeocodeNoEdgesSchema],
+    geocode_cluster_df: pl.DataFrame,
+    geocode_lf: pl.LazyFrame,
     permutations: int = 999,  # Default permutations
-) -> dy.DataFrame[PermanovaResultsSchema]:
+) -> pl.DataFrame:
     """
     Runs the PERMANOVA test and stores the results.
 
@@ -60,4 +45,4 @@ def build_permanova_results_df(
         permutations,
     )
 
-    return PermanovaResultsSchema.validate(df)
+    return df

--- a/src/dataframes/significant_taxa_images.py
+++ b/src/dataframes/significant_taxa_images.py
@@ -1,16 +1,11 @@
 import logging
 from typing import Dict, List
 
-import dataframely as dy
 import polars as pl
 import requests
 
 logger = logging.getLogger(__name__)
 
-from src.dataframes.cluster_significant_differences import (
-    ClusterSignificantDifferencesSchema,
-)
-from src.dataframes.taxonomy import TaxonomySchema
 
 
 def _fetch_wikidata_images(gbif_taxon_ids: List[int]) -> Dict[int, str]:
@@ -58,18 +53,10 @@ def _fetch_wikidata_images(gbif_taxon_ids: List[int]) -> Dict[int, str]:
         print(f"Error fetching from Wikidata: {e}")
         return {}
 
-
-class SignificantTaxaImagesSchema(dy.Schema):
-    taxonId = dy.UInt32(nullable=False)
-    image_url = dy.String(nullable=True)
-
-
 def build_significant_taxa_images_df(
-    cluster_significant_differences_df: dy.DataFrame[
-        ClusterSignificantDifferencesSchema
-    ],
-    taxonomy_df: dy.DataFrame[TaxonomySchema],
-) -> dy.DataFrame[SignificantTaxaImagesSchema]:
+    cluster_significant_differences_df: pl.DataFrame,
+    taxonomy_df: pl.DataFrame,
+) -> pl.DataFrame:
     """Build a SignificantTaxaImagesSchema DataFrame with image URLs from Wikidata.
 
     Fetches image URLs from Wikidata for taxa that have significant differences
@@ -95,11 +82,9 @@ def build_significant_taxa_images_df(
     image_map = _fetch_wikidata_images(gbif_ids)
 
     if not image_map:
-        return SignificantTaxaImagesSchema.validate(
-            significant_taxa_df.with_columns(
+        return significant_taxa_df.with_columns(
                 image_url=pl.lit(None, dtype=pl.String)
             ).select(["taxonId", "image_url"])
-        )
 
     images_df = pl.DataFrame(
         {
@@ -113,4 +98,4 @@ def build_significant_taxa_images_df(
         images_df, on="gbifTaxonId", how="left"
     ).select(["taxonId", "image_url"])
 
-    return SignificantTaxaImagesSchema.validate(result_df)
+    return result_df

--- a/src/dataframes/taxonomy.py
+++ b/src/dataframes/taxonomy.py
@@ -1,32 +1,18 @@
 import logging
 
-import dataframely as dy
 import polars as pl
 
-from src.dataframes.darwin_core import DarwinCoreSchema
-from src.dataframes.geocode import GeocodeNoEdgesSchema
 from src.geocode import filter_by_bounding_box, with_geocode_lf
 from src.types import Bbox
 
 logger = logging.getLogger(__name__)
 
-
-class TaxonomySchema(dy.Schema):
-    """
-    A dataframe of taxonomy information. Note that this may include taxa for geocodes that were filtered out.
-    """
-
-    taxonId = dy.UInt32(nullable=False)  # Unique identifier for each taxon
-    scientificName = dy.String(nullable=True)
-    gbifTaxonId = dy.UInt32(nullable=False)
-
-
 def build_taxonomy_lf(
-    darwin_core_lf: dy.LazyFrame[DarwinCoreSchema],
+    darwin_core_lf: pl.LazyFrame,
     geocode_precision: int,
-    geocode_lf: dy.LazyFrame[GeocodeNoEdgesSchema],
+    geocode_lf: pl.LazyFrame,
     bounding_box: Bbox,
-) -> dy.LazyFrame[TaxonomySchema]:
+) -> pl.LazyFrame:
     """Build a validated TaxonomySchema LazyFrame from Darwin Core data.
 
     Args:
@@ -65,4 +51,4 @@ def build_taxonomy_lf(
         .cast({"taxonId": pl.UInt32})
     )
 
-    return TaxonomySchema.validate(lf, eager=False)
+    return lf

--- a/src/geojson.py
+++ b/src/geojson.py
@@ -1,15 +1,13 @@
-import dataframely as dy
 
+import polars as pl
 import bioregion_rs
 import geojson
 from src import output
-from src.dataframes.cluster_boundary import ClusterBoundarySchema
-from src.dataframes.cluster_color import ClusterColorSchema
 
 
 def build_geojson_feature_collection(
-    cluster_boundary_df: dy.DataFrame[ClusterBoundarySchema],
-    cluster_colors_df: dy.DataFrame[ClusterColorSchema],
+    cluster_boundary_df: pl.DataFrame,
+    cluster_colors_df: pl.DataFrame,
 ) -> geojson.FeatureCollection:
     rust_json = bioregion_rs.build_geojson_feature_collection(
         cluster_boundary_df, cluster_colors_df

--- a/src/matrices/cluster_distance.py
+++ b/src/matrices/cluster_distance.py
@@ -3,15 +3,13 @@ import polars as pl
 from typing import Tuple, List
 from sklearn.preprocessing import RobustScaler
 from scipy.spatial.distance import squareform
-from src.dataframes.cluster_taxa_statistics import ClusterTaxaStatisticsSchema
-import dataframely as dy
 
 import bioregion_rs
 from src.logging import log_action
 
 
 def pivot_taxon_counts_for_clusters(
-    cluster_taxa_stats: dy.DataFrame[ClusterTaxaStatisticsSchema],
+    cluster_taxa_stats: pl.DataFrame,
 ) -> pl.DataFrame:
     """
     Create a matrix where each row is a cluster and each column is a taxon ID.
@@ -42,7 +40,7 @@ def pivot_taxon_counts_for_clusters(
 
 
 def build_X(
-    cluster_taxa_stats: dy.DataFrame[ClusterTaxaStatisticsSchema],
+    cluster_taxa_stats: pl.DataFrame,
 ) -> Tuple[pl.DataFrame, List[int]]:
     X = log_action(
         "Building cluster matrix",
@@ -85,7 +83,7 @@ class ClusterDistanceMatrix:
     @classmethod
     def build(
         cls,
-        cluster_taxa_stats: dy.DataFrame[ClusterTaxaStatisticsSchema],
+        cluster_taxa_stats: pl.DataFrame,
     ) -> "ClusterDistanceMatrix":
         condensed, cluster_ids = bioregion_rs.build_cluster_distance_matrix(
             cluster_taxa_stats

--- a/src/matrices/geocode_connectivity.py
+++ b/src/matrices/geocode_connectivity.py
@@ -1,10 +1,9 @@
+import polars as pl
 import logging
 
-import dataframely as dy
 import numpy as np
 
 import bioregion_rs
-from src.dataframes.geocode_neighbors import GeocodeNeighborsSchema
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +16,7 @@ class GeocodeConnectivityMatrix:
 
     @classmethod
     def build(
-        cls, geocode_neighbors_df: dy.DataFrame[GeocodeNeighborsSchema]
+        cls, geocode_neighbors_df: pl.DataFrame
     ) -> "GeocodeConnectivityMatrix":
         """Build a connectivity matrix from geocode neighbor relationships.
 

--- a/src/matrices/geocode_distance.py
+++ b/src/matrices/geocode_distance.py
@@ -1,4 +1,3 @@
-import dataframely as dy
 import numpy as np
 import polars as pl
 import umap
@@ -6,7 +5,6 @@ from scipy.spatial.distance import pdist, squareform
 from sklearn.preprocessing import RobustScaler
 
 from src.dataframes import geocode_taxa_counts
-from src.dataframes.geocode import GeocodeNoEdgesSchema
 from src.logging import log_action, logger
 
 
@@ -57,8 +55,8 @@ def pivot_taxon_counts(taxon_counts: pl.LazyFrame) -> pl.LazyFrame:
 
 
 def build_X(
-    geocode_taxa_counts_lf: dy.LazyFrame[geocode_taxa_counts.GeocodeTaxaCountsSchema],
-    geocode_lf: dy.LazyFrame[GeocodeNoEdgesSchema],
+    geocode_taxa_counts_lf: pl.LazyFrame,
+    geocode_lf: pl.LazyFrame,
 ) -> pl.DataFrame:
     """
     Builds the feature matrix (X) for distance calculation.
@@ -174,10 +172,8 @@ class GeocodeDistanceMatrix:
     @classmethod
     def build(
         cls,
-        geocode_taxa_counts_lf: dy.LazyFrame[
-            geocode_taxa_counts.GeocodeTaxaCountsSchema
-        ],
-        geocode_lf: dy.LazyFrame[GeocodeNoEdgesSchema],
+        geocode_taxa_counts_lf: pl.LazyFrame,
+        geocode_lf: pl.LazyFrame,
         umap_n_components: int | None = None,
         umap_min_dist: float = 0.5,
     ) -> "GeocodeDistanceMatrix":

--- a/src/output.py
+++ b/src/output.py
@@ -6,20 +6,13 @@ to ensure consistent output file handling across the project. It also includes
 functionality for writing JSON output files.
 """
 
+import polars as pl
 import logging
 import os
 from typing import Optional
 
-import dataframely as dy
 
 import bioregion_rs
-from src.dataframes.cluster_boundary import ClusterBoundarySchema
-from src.dataframes.cluster_color import ClusterColorSchema
-from src.dataframes.cluster_significant_differences import (
-    ClusterSignificantDifferencesSchema,
-)
-from src.dataframes.significant_taxa_images import SignificantTaxaImagesSchema
-from src.dataframes.taxonomy import TaxonomySchema
 
 # Default output directory
 OUTPUT_DIR = "output"
@@ -102,13 +95,11 @@ def prepare_file_path(path: str) -> str:
 
 
 def write_json_output(
-    cluster_significant_differences_df: dy.DataFrame[
-        ClusterSignificantDifferencesSchema
-    ],
-    cluster_boundary_df: dy.DataFrame[ClusterBoundarySchema],
-    taxonomy_df: dy.DataFrame[TaxonomySchema],
-    cluster_color_df: dy.DataFrame[ClusterColorSchema],
-    significant_taxa_images_df: dy.DataFrame[SignificantTaxaImagesSchema],
+    cluster_significant_differences_df: pl.DataFrame,
+    cluster_boundary_df: pl.DataFrame,
+    taxonomy_df: pl.DataFrame,
+    cluster_color_df: pl.DataFrame,
+    significant_taxa_images_df: pl.DataFrame,
     output_path: str,
 ) -> None:
     """

--- a/src/plot/cluster_metrics.py
+++ b/src/plot/cluster_metrics.py
@@ -10,7 +10,6 @@ cluster optimization results.
 import logging
 from typing import Optional
 
-import dataframely as dy
 import matplotlib.figure
 import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
@@ -19,7 +18,6 @@ import polars as pl
 
 from src.dataframes.geocode_cluster_metrics import (
     ElbowAnalysisResult,
-    GeocodeClusterMetricsSchema,
     get_metric_interpretations,
     get_elbow_analysis,
 )
@@ -28,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 def plot_all_metrics_vs_k(
-    metrics_df: dy.DataFrame[GeocodeClusterMetricsSchema],
+    metrics_df: pl.DataFrame,
     optimal_k: Optional[int] = None,
     figsize: tuple[float, float] = (14, 10),
     save_path: Optional[str] = None,
@@ -177,7 +175,7 @@ def _highlight_optimal(
 
 
 def plot_elbow_curve(
-    metrics_df: dy.DataFrame[GeocodeClusterMetricsSchema],
+    metrics_df: pl.DataFrame,
     optimal_k: Optional[int] = None,
     show_distances: bool = True,
     figsize: tuple[float, float] = (12, 8),
@@ -327,7 +325,7 @@ def plot_elbow_curve(
 
 
 def plot_elbow_derivatives(
-    metrics_df: dy.DataFrame[GeocodeClusterMetricsSchema],
+    metrics_df: pl.DataFrame,
     optimal_k: Optional[int] = None,
     figsize: tuple[float, float] = (14, 5),
     save_path: Optional[str] = None,
@@ -412,7 +410,7 @@ def plot_elbow_derivatives(
 
 
 def plot_normalized_metrics(
-    metrics_df: dy.DataFrame[GeocodeClusterMetricsSchema],
+    metrics_df: pl.DataFrame,
     optimal_k: Optional[int] = None,
     include_inertia: bool = False,
     figsize: tuple[float, float] = (12, 6),
@@ -497,7 +495,7 @@ def plot_normalized_metrics(
 
 
 def plot_metric_rankings(
-    metrics_df: dy.DataFrame[GeocodeClusterMetricsSchema],
+    metrics_df: pl.DataFrame,
     optimal_k: Optional[int] = None,
     figsize: tuple[float, float] = (10, 6),
     save_path: Optional[str] = None,
@@ -585,7 +583,7 @@ def plot_metric_rankings(
 
 
 def plot_metrics_summary(
-    metrics_df: dy.DataFrame[GeocodeClusterMetricsSchema],
+    metrics_df: pl.DataFrame,
     optimal_k: Optional[int] = None,
     selection_method: str = "combined",
     figsize: tuple[float, float] = (16, 12),

--- a/src/plot/cluster_taxa.py
+++ b/src/plot/cluster_taxa.py
@@ -1,19 +1,12 @@
 import logging
 from typing import Dict, TypeVar, Union, cast
 
-import dataframely as dy
 import polars as pl
 import seaborn as sns
 from scipy.cluster.hierarchy import linkage
 
-from src.dataframes.cluster_color import ClusterColorSchema, get_color_for_cluster
-from src.dataframes.cluster_significant_differences import (
-    ClusterSignificantDifferencesSchema,
-)
-from src.dataframes.cluster_taxa_statistics import ClusterTaxaStatisticsSchema
-from src.dataframes.geocode import GeocodeNoEdgesSchema
-from src.dataframes.geocode_cluster import GeocodeClusterSchema, cluster_for_geocode
-from src.dataframes.geocode_taxa_counts import GeocodeTaxaCountsSchema
+from src.dataframes.cluster_color import get_color_for_cluster
+from src.dataframes.geocode_cluster import cluster_for_geocode
 
 NumericSeries = TypeVar("NumericSeries", bound=pl.Series)
 
@@ -21,16 +14,14 @@ logger = logging.getLogger(__name__)
 
 
 def create_cluster_taxa_heatmap(
-    geocode_lf: dy.LazyFrame[GeocodeNoEdgesSchema],
-    geocode_cluster_df: dy.DataFrame[GeocodeClusterSchema],
-    cluster_colors_df: dy.DataFrame["ClusterColorSchema"],
+    geocode_lf: pl.LazyFrame,
+    geocode_cluster_df: pl.DataFrame,
+    cluster_colors_df: pl.DataFrame,
     geocode_distance_matrix,
-    cluster_significant_differences_df: dy.DataFrame[
-        "ClusterSignificantDifferencesSchema"
-    ],
+    cluster_significant_differences_df: pl.DataFrame,
     taxonomy_df,
-    geocode_taxa_counts_lf: dy.LazyFrame[GeocodeTaxaCountsSchema],
-    cluster_taxa_statistics_df: dy.DataFrame[ClusterTaxaStatisticsSchema],
+    geocode_taxa_counts_lf: pl.LazyFrame,
+    cluster_taxa_statistics_df: pl.DataFrame,
     limit_species=None,
 ):
     logger.info("create_cluster_taxa_heatmap: Starting")

--- a/src/plot/dimensionality_reduction.py
+++ b/src/plot/dimensionality_reduction.py
@@ -1,21 +1,19 @@
 from typing import Literal
 
 import altair as alt
-import dataframely as dy
 import numpy as np
 import polars as pl
 import umap
 from sklearn.manifold import TSNE
 
-from src.dataframes.cluster_color import ClusterColorSchema, to_dict
-from src.dataframes.geocode_cluster import GeocodeClusterSchema
+from src.dataframes.cluster_color import to_dict
 from src.matrices.cluster_distance import ClusterDistanceMatrix
 
 
 def create_dimensionality_reduction_plot(
     geocode_distance_matrix: ClusterDistanceMatrix,
-    geocode_cluster_df: dy.DataFrame[GeocodeClusterSchema],
-    cluster_color_df: dy.DataFrame[ClusterColorSchema],
+    geocode_cluster_df: pl.DataFrame,
+    cluster_color_df: pl.DataFrame,
     method: Literal["umap", "tsne"] = "umap",
     n_neighbors: int = 3000,
 ) -> alt.Chart:
@@ -26,9 +24,9 @@ def create_dimensionality_reduction_plot(
     -----------
     geocode_distance_matrix : ClusterDistanceMatrix
         Distance matrix with squareform method
-    geocode_cluster_df : dy.DataFrame[GeocodeClusterSchema]
+    geocode_cluster_df : pl.DataFrame
         DataFrame containing cluster information
-    cluster_color_df : dy.DataFrame[ClusterColorSchema]
+    cluster_color_df : pl.DataFrame
         DataFrame with color mapping for clusters
     method : str, optional
         Dimensionality reduction method to use ('umap' or 'tsne'), default 'umap'

--- a/src/plot/silhouette_score.py
+++ b/src/plot/silhouette_score.py
@@ -1,19 +1,16 @@
-import dataframely as dy
 import matplotlib.pyplot as plt
 import numpy as np
 import polars as pl
 
-from src.dataframes.cluster_color import ClusterColorSchema, get_color_for_cluster
-from src.dataframes.geocode_cluster import GeocodeClusterSchema
-from src.dataframes.geocode_silhouette_score import GeocodeSilhouetteScoreSchema
+from src.dataframes.cluster_color import get_color_for_cluster
 from src.matrices.geocode_distance import GeocodeDistanceMatrix
 
 
 def plot_silhouette_scores(
-    geocode_cluster_df: dy.DataFrame[GeocodeClusterSchema],
+    geocode_cluster_df: pl.DataFrame,
     geocode_distance_matrix: GeocodeDistanceMatrix,
-    geocode_silhouette_score_df: dy.DataFrame[GeocodeSilhouetteScoreSchema],
-    cluster_colors_df: dy.DataFrame[ClusterColorSchema],
+    geocode_silhouette_score_df: pl.DataFrame,
+    cluster_colors_df: pl.DataFrame,
 ) -> plt.Figure:  # type: ignore
     """
     Create a silhouette plot for clustering results.

--- a/test/fixtures/cluster_boundary.py
+++ b/test/fixtures/cluster_boundary.py
@@ -1,11 +1,9 @@
-import dataframely as dy
 import polars as pl
 import shapely
 
-from src.dataframes.cluster_boundary import ClusterBoundarySchema
 
 
-def mock_cluster_boundary_df() -> dy.DataFrame[ClusterBoundarySchema]:
+def mock_cluster_boundary_df() -> pl.DataFrame:
     """
     Creates a mock ClusterBoundaryDataFrame for testing.
     """
@@ -42,4 +40,4 @@ def mock_cluster_boundary_df() -> dy.DataFrame[ClusterBoundarySchema]:
         ]
     ).with_columns(pl.col("cluster").cast(pl.UInt32()))
 
-    return ClusterBoundarySchema.validate(cluster_boundary_df)
+    return cluster_boundary_df

--- a/test/fixtures/cluster_color.py
+++ b/test/fixtures/cluster_color.py
@@ -1,10 +1,8 @@
-import dataframely as dy
 import polars as pl
 
-from src.dataframes.cluster_color import ClusterColorSchema
 
 
-def mock_cluster_color_df() -> dy.DataFrame[ClusterColorSchema]:
+def mock_cluster_color_df() -> pl.DataFrame:
     """
     Creates a mock ClusterColorDataFrame for testing.
     """
@@ -14,4 +12,4 @@ def mock_cluster_color_df() -> dy.DataFrame[ClusterColorSchema]:
             {"cluster": 2, "color": "#0000ff", "darkened_color": "#000080"},
         ],
     ).with_columns(pl.col("cluster").cast(pl.UInt32))
-    return ClusterColorSchema.validate(df)
+    return df

--- a/test/fixtures/cluster_taxa_statistics.py
+++ b/test/fixtures/cluster_taxa_statistics.py
@@ -1,10 +1,8 @@
-import dataframely as dy
 import polars as pl
 
-from src.dataframes.cluster_taxa_statistics import ClusterTaxaStatisticsSchema
 
 
-def mock_cluster_taxa_statistics_df() -> dy.DataFrame[ClusterTaxaStatisticsSchema]:
+def mock_cluster_taxa_statistics_df() -> pl.DataFrame:
     """
     Creates a mock ClusterTaxaStatisticsDataFrame for testing.
     """
@@ -22,4 +20,4 @@ def mock_cluster_taxa_statistics_df() -> dy.DataFrame[ClusterTaxaStatisticsSchem
             "average": pl.Float64(),
         },
     )
-    return ClusterTaxaStatisticsSchema.validate(taxa_stats_df)
+    return taxa_stats_df

--- a/test/fixtures/geocode.py
+++ b/test/fixtures/geocode.py
@@ -1,12 +1,10 @@
-import dataframely as dy
 import polars as pl
 import polars_st as pl_st
 import shapely
 
-from src.dataframes.geocode import GeocodeNoEdgesSchema
 
 
-def mock_geocode_no_edges_df() -> dy.DataFrame[GeocodeNoEdgesSchema]:
+def mock_geocode_no_edges_df() -> pl.DataFrame:
     """
     Creates a mock GeocodeNoEdgesSchema DataFrame for testing.
 
@@ -52,4 +50,4 @@ def mock_geocode_no_edges_df() -> dy.DataFrame[GeocodeNoEdgesSchema]:
         pl_st.from_shapely(pl.Series(boundaries)).alias("boundary"),
     )
 
-    return GeocodeNoEdgesSchema.validate(df)
+    return df

--- a/test/fixtures/geocode_cluster.py
+++ b/test/fixtures/geocode_cluster.py
@@ -1,13 +1,8 @@
-import dataframely as dy
 import polars as pl
 
-from src.dataframes.geocode_cluster import (
-    GeocodeClusterMultiKSchema,
-    GeocodeClusterSchema,
-)
 
 
-def mock_geocode_cluster_df(num_clusters: int = 2) -> dy.DataFrame[GeocodeClusterSchema]:
+def mock_geocode_cluster_df(num_clusters: int = 2) -> pl.DataFrame:
     """
     Creates a mock GeocodeClusterDataFrame for testing (single k value).
 
@@ -23,12 +18,12 @@ def mock_geocode_cluster_df(num_clusters: int = 2) -> dy.DataFrame[GeocodeCluste
         pl.col("geocode").cast(pl.UInt64),
         pl.col("cluster").cast(pl.UInt32),
     )
-    return GeocodeClusterSchema.validate(df)
+    return df
 
 
 def mock_geocode_cluster_multi_k_df(
     num_clusters: int = 2,
-) -> dy.DataFrame[GeocodeClusterMultiKSchema]:
+) -> pl.DataFrame:
     """
     Creates a mock GeocodeClusterDataFrame for testing (with num_clusters field).
 
@@ -45,4 +40,4 @@ def mock_geocode_cluster_multi_k_df(
         pl.col("num_clusters").cast(pl.UInt32),
         pl.col("cluster").cast(pl.UInt32),
     )
-    return GeocodeClusterMultiKSchema.validate(df)
+    return df

--- a/test/fixtures/geocode_neighbors.py
+++ b/test/fixtures/geocode_neighbors.py
@@ -1,10 +1,8 @@
-import dataframely as dy
 import polars as pl
 
-from src.dataframes.geocode_neighbors import GeocodeNeighborsSchema
 
 
-def mock_geocode_neighbors_df() -> dy.DataFrame[GeocodeNeighborsSchema]:
+def mock_geocode_neighbors_df() -> pl.DataFrame:
     """
     Creates a mock GeocodeNeighborsSchema DataFrame for testing.
 
@@ -39,4 +37,4 @@ def mock_geocode_neighbors_df() -> dy.DataFrame[GeocodeNeighborsSchema]:
         pl.col("direct_and_indirect_neighbors").cast(pl.List(pl.UInt64)),
     )
 
-    return GeocodeNeighborsSchema.validate(df)
+    return df

--- a/test/fixtures/geocode_taxa_counts.py
+++ b/test/fixtures/geocode_taxa_counts.py
@@ -1,10 +1,8 @@
-import dataframely as dy
 import polars as pl
 
-from src.dataframes.geocode_taxa_counts import GeocodeTaxaCountsSchema
 
 
-def mock_geocode_taxa_counts_df() -> dy.DataFrame[GeocodeTaxaCountsSchema]:
+def mock_geocode_taxa_counts_df() -> pl.DataFrame:
     """
     Creates a mock GeocodeTaxaCountsDataFrame for testing.
     """
@@ -21,4 +19,4 @@ def mock_geocode_taxa_counts_df() -> dy.DataFrame[GeocodeTaxaCountsSchema]:
         pl.col("taxonId").cast(pl.UInt32),
         pl.col("count").cast(pl.UInt32),
     )
-    return GeocodeTaxaCountsSchema.validate(geocode_taxa_counts_df)
+    return geocode_taxa_counts_df

--- a/test/fixtures/taxonomy.py
+++ b/test/fixtures/taxonomy.py
@@ -1,10 +1,8 @@
-import dataframely as dy
 import polars as pl
 
-from src.dataframes.taxonomy import TaxonomySchema
 
 
-def mock_taxonomy_lf() -> dy.LazyFrame[TaxonomySchema]:
+def mock_taxonomy_lf() -> pl.LazyFrame:
     """
     Creates a mock TaxonomyLazyFrame for testing.
     """
@@ -63,4 +61,4 @@ def mock_taxonomy_lf() -> dy.LazyFrame[TaxonomySchema]:
         pl.col("genus").cast(pl.Categorical),
         pl.col("gbifTaxonId").cast(pl.UInt32),
     )
-    return TaxonomySchema.validate(taxonomy_df).lazy()
+    return taxonomy_df.lazy()

--- a/test/test_cluster_color.py
+++ b/test/test_cluster_color.py
@@ -1,21 +1,15 @@
 import unittest
 
-import dataframely as dy
 import networkx as nx
 import numpy as np
 import polars as pl
 import shapely
 
 from src.dataframes.cluster_color import (
-    ClusterColorSchema,
     build_cluster_color_df,
     to_dict,
 )
-from src.dataframes.cluster_neighbors import ClusterNeighborsSchema
-from src.dataframes.cluster_taxa_statistics import ClusterTaxaStatisticsSchema
-from test.fixtures.cluster_taxa_statistics import (
-    mock_cluster_taxa_statistics_df,
-)
+from test.fixtures.cluster_taxa_statistics import mock_cluster_taxa_statistics_df
 
 
 class TestClusterColorSchema(unittest.TestCase):
@@ -35,7 +29,7 @@ class TestClusterColorSchema(unittest.TestCase):
                 "direct_and_indirect_neighbors": pl.List(pl.UInt32),
             },
         )
-        cluster_neighbors = ClusterNeighborsSchema.validate(neighbors_df)
+        cluster_neighbors = neighbors_df
 
         # Generate colors
         color_df = build_cluster_color_df(cluster_neighbors.lazy())
@@ -71,7 +65,7 @@ class TestClusterColorSchema(unittest.TestCase):
                 "direct_and_indirect_neighbors": pl.List(pl.UInt32),
             },
         )
-        cluster_neighbors = ClusterNeighborsSchema.validate(neighbors_df)
+        cluster_neighbors = neighbors_df
 
         # Generate colors
         color_df = build_cluster_color_df(cluster_neighbors.lazy())
@@ -112,7 +106,7 @@ class TestClusterColorSchema(unittest.TestCase):
                 "direct_and_indirect_neighbors": pl.List(pl.UInt32),
             },
         )
-        cluster_neighbors = ClusterNeighborsSchema.validate(neighbors_df)
+        cluster_neighbors = neighbors_df
 
         # Verify that attempting to use UMAP with too few clusters raises an AssertionError
         with self.assertRaises(AssertionError) as context:
@@ -185,7 +179,7 @@ class TestClusterColorSchema(unittest.TestCase):
             .alias("cluster")
         )
 
-        cluster_taxa_stats = ClusterTaxaStatisticsSchema.validate(taxa_stats_df)
+        cluster_taxa_stats = taxa_stats_df
 
         # Create dummy neighbor data (not used for taxonomic coloring)
         neighbors_df = pl.DataFrame(
@@ -200,7 +194,7 @@ class TestClusterColorSchema(unittest.TestCase):
                 "direct_and_indirect_neighbors": pl.List(pl.UInt32),
             },
         )
-        cluster_neighbors = ClusterNeighborsSchema.validate(neighbors_df)
+        cluster_neighbors = neighbors_df
 
         # Generate colors using the UMAP-based approach
         color_df = build_cluster_color_df(

--- a/test/test_cluster_distance.py
+++ b/test/test_cluster_distance.py
@@ -1,18 +1,14 @@
 import unittest
 
-import dataframely as dy
 import numpy as np
 import polars as pl
 
-from src.dataframes.cluster_taxa_statistics import ClusterTaxaStatisticsSchema
 from src.matrices.cluster_distance import (
     ClusterDistanceMatrix,
     build_X,
     pivot_taxon_counts_for_clusters,
 )
-from test.fixtures.cluster_taxa_statistics import (
-    mock_cluster_taxa_statistics_df,
-)
+from test.fixtures.cluster_taxa_statistics import mock_cluster_taxa_statistics_df
 
 
 class TestClusterDistanceMatrix(unittest.TestCase):
@@ -33,7 +29,7 @@ class TestClusterDistanceMatrix(unittest.TestCase):
                 "average": pl.Float64(),
             },
         )
-        cluster_taxa_stats = ClusterTaxaStatisticsSchema.validate(df)
+        cluster_taxa_stats = df
 
         # Run the pivot function
         result = pivot_taxon_counts_for_clusters(cluster_taxa_stats)
@@ -87,7 +83,7 @@ class TestClusterDistanceMatrix(unittest.TestCase):
                 "average": pl.Float64(),
             },
         )
-        cluster_taxa_stats = ClusterTaxaStatisticsSchema.validate(df)
+        cluster_taxa_stats = df
 
         # Build the distance matrix
         distance_matrix = ClusterDistanceMatrix.build(cluster_taxa_stats)
@@ -135,7 +131,7 @@ class TestClusterDistanceMatrix(unittest.TestCase):
             },
         )
 
-        cluster_taxa_stats = ClusterTaxaStatisticsSchema.validate(df)
+        cluster_taxa_stats = df
 
         # Use a custom implementation to build the matrix to have more control
         X, cluster_ids = build_X(cluster_taxa_stats)

--- a/test/test_cluster_metrics.py
+++ b/test/test_cluster_metrics.py
@@ -6,13 +6,10 @@ Tests the GeocodeClusterMetricsSchema, builder functions, and selection logic.
 
 import unittest
 
-import dataframely as dy
 import numpy as np
 import polars as pl
 
-from src.dataframes.geocode_cluster import GeocodeClusterMultiKSchema
 from src.dataframes.geocode_cluster_metrics import (
-    GeocodeClusterMetricsSchema,
     build_geocode_cluster_metrics_df,
     get_metric_interpretations,
     get_metrics_summary,
@@ -24,7 +21,7 @@ from src.matrices.geocode_distance import GeocodeDistanceMatrix
 def mock_geocode_cluster_multi_k_df(
     num_geocodes: int = 10,
     k_values: list[int] | None = None,
-) -> dy.DataFrame[GeocodeClusterMultiKSchema]:
+) -> pl.DataFrame:
     """Create a mock multi-k clustering DataFrame for testing."""
     if k_values is None:
         k_values = [2, 3, 4, 5]
@@ -48,7 +45,7 @@ def mock_geocode_cluster_multi_k_df(
         pl.col("cluster").cast(pl.UInt32),
     )
 
-    return GeocodeClusterMultiKSchema.validate(df)
+    return df
 
 
 def mock_distance_matrix(num_geocodes: int = 10) -> GeocodeDistanceMatrix:
@@ -90,28 +87,8 @@ class TestGeocodeClusterMetricsSchema(unittest.TestCase):
             }
         ).with_columns(pl.col("num_clusters").cast(pl.UInt32))
 
-        validated = GeocodeClusterMetricsSchema.validate(df)
+        validated = df
         self.assertEqual(len(validated), 3)
-
-    def test_schema_requires_num_clusters(self):
-        """Test that num_clusters column is required."""
-        df = pl.DataFrame(
-            {
-                "silhouette_score": [0.5],
-                "calinski_harabasz_score": [100.0],
-                "davies_bouldin_score": [0.8],
-                "inertia": [500.0],
-                "silhouette_normalized": [0.75],
-                "calinski_harabasz_normalized": [0.5],
-                "davies_bouldin_normalized": [0.5],
-                "inertia_normalized": [0.5],
-                "combined_score": [0.6],
-            }
-        )
-
-        with self.assertRaises(Exception):
-            GeocodeClusterMetricsSchema.validate(df)
-
 
 class TestBuildGeocodeClusterMetricsDf(unittest.TestCase):
     """Tests for build_geocode_cluster_metrics_df function."""
@@ -234,10 +211,10 @@ class TestSelectOptimalKMultiMetric(unittest.TestCase):
 
     def create_metrics_df(
         self, scores: list[dict[str, float]]
-    ) -> dy.DataFrame[GeocodeClusterMetricsSchema]:
+    ) -> pl.DataFrame:
         """Helper to create a metrics DataFrame from score dicts."""
         df = pl.DataFrame(scores).with_columns(pl.col("num_clusters").cast(pl.UInt32))
-        return GeocodeClusterMetricsSchema.validate(df)
+        return df
 
     def test_returns_none_when_elbow_not_found(self):
         """Test that None is returned when elbow method can't find a clear elbow."""
@@ -304,7 +281,7 @@ class TestGetMetricsSummary(unittest.TestCase):
             }
         ).with_columns(pl.col("num_clusters").cast(pl.UInt32))
 
-        metrics_df = GeocodeClusterMetricsSchema.validate(df)
+        metrics_df = df
         summary = get_metrics_summary(metrics_df)
 
         # Should be sorted by combined_score descending
@@ -328,7 +305,7 @@ class TestGetMetricsSummary(unittest.TestCase):
             }
         ).with_columns(pl.col("num_clusters").cast(pl.UInt32))
 
-        metrics_df = GeocodeClusterMetricsSchema.validate(df)
+        metrics_df = df
         summary = get_metrics_summary(metrics_df)
 
         expected_columns = {

--- a/test/test_cluster_optimization.py
+++ b/test/test_cluster_optimization.py
@@ -5,7 +5,6 @@ import polars as pl
 
 from src.cluster_optimization import optimize_num_clusters
 from src.dataframes.geocode_cluster_metrics import (
-    GeocodeClusterMetricsSchema,
     _compute_inertia,
     _find_elbow_point,
     get_elbow_analysis,
@@ -148,9 +147,7 @@ class TestElbowMethod(unittest.TestCase):
         ).with_columns(
             pl.col("num_clusters").cast(pl.UInt32),
         )
-        self.mock_metrics_df = GeocodeClusterMetricsSchema.validate(
-            self.mock_metrics_data
-        )
+        self.mock_metrics_df = self.mock_metrics_data
 
     def test_find_elbow_point_clear_elbow(self):
         """Test elbow detection with a clear elbow pattern."""
@@ -177,7 +174,7 @@ class TestElbowMethod(unittest.TestCase):
                 "combined_score": [0.27, 0.71],
             }
         ).with_columns(pl.col("num_clusters").cast(pl.UInt32))
-        few_points_df = GeocodeClusterMetricsSchema.validate(few_points)
+        few_points_df = few_points
 
         elbow_k = _find_elbow_point(few_points_df)
         self.assertIsNone(elbow_k)
@@ -199,7 +196,7 @@ class TestElbowMethod(unittest.TestCase):
                 "combined_score": [0.57] * 5,
             }
         ).with_columns(pl.col("num_clusters").cast(pl.UInt32))
-        linear_df = GeocodeClusterMetricsSchema.validate(linear_data)
+        linear_df = linear_data
 
         # For linear decrease, Kneedle algorithm correctly returns None (no elbow)
         elbow_k = _find_elbow_point(linear_df)

--- a/test/test_cluster_significant_differences.py
+++ b/test/test_cluster_significant_differences.py
@@ -1,14 +1,8 @@
 import unittest
 
-import dataframely as dy
 import polars as pl
 
-from src.dataframes.cluster_neighbors import ClusterNeighborsSchema
-from src.dataframes.cluster_significant_differences import (
-    ClusterSignificantDifferencesSchema,
-    build_cluster_significant_differences_df,
-)
-from src.dataframes.cluster_taxa_statistics import ClusterTaxaStatisticsSchema
+from src.dataframes.cluster_significant_differences import build_cluster_significant_differences_df
 
 
 class TestClusterSignificantDifferences(unittest.TestCase):
@@ -29,7 +23,7 @@ class TestClusterSignificantDifferences(unittest.TestCase):
                 "average": pl.Float64(),
             },
         )
-        cluster_taxa_stats = ClusterTaxaStatisticsSchema.validate(taxa_stats_df)
+        cluster_taxa_stats = taxa_stats_df
 
         # Mock cluster neighbors
         neighbors_df = pl.DataFrame(
@@ -44,7 +38,7 @@ class TestClusterSignificantDifferences(unittest.TestCase):
                 "direct_and_indirect_neighbors": pl.List(pl.UInt32()),
             },
         )
-        cluster_neighbors = ClusterNeighborsSchema.validate(neighbors_df)
+        cluster_neighbors = neighbors_df
 
         # Build significant differences
         significant_differences_df = build_cluster_significant_differences_df(

--- a/test/test_cluster_taxa_heatmap.py
+++ b/test/test_cluster_taxa_heatmap.py
@@ -7,21 +7,11 @@ regression tests for bugs that have been fixed.
 
 import unittest
 
-import dataframely as dy
 import numpy as np
 import polars as pl
 import polars_st as pl_st
 import shapely
 
-from src.dataframes.cluster_color import ClusterColorSchema
-from src.dataframes.cluster_significant_differences import (
-    ClusterSignificantDifferencesSchema,
-)
-from src.dataframes.cluster_taxa_statistics import ClusterTaxaStatisticsSchema
-from src.dataframes.geocode import GeocodeNoEdgesSchema
-from src.dataframes.geocode_cluster import GeocodeClusterSchema
-from src.dataframes.geocode_taxa_counts import GeocodeTaxaCountsSchema
-from src.dataframes.taxonomy import TaxonomySchema
 from src.plot.cluster_taxa import create_cluster_taxa_heatmap
 
 
@@ -85,7 +75,7 @@ class TestClusterTaxaHeatmap(unittest.TestCase):
             pl_st.from_shapely(pl.Series(centers)).alias("center"),
             pl_st.from_shapely(pl.Series(boundaries)).alias("boundary"),
         )
-        geocode_lf = GeocodeNoEdgesSchema.validate(geocode_df, eager=False)
+        geocode_lf = geocode_df.lazy()
 
         # Create geocode_taxa_counts with data for only 2 of the 3 geocodes
         # Geocode 3000 intentionally has NO taxa data
@@ -100,13 +90,10 @@ class TestClusterTaxaHeatmap(unittest.TestCase):
             pl.col("taxonId").cast(pl.UInt32),
             pl.col("count").cast(pl.UInt32),
         )
-        geocode_taxa_counts_lf = GeocodeTaxaCountsSchema.validate(
-            geocode_taxa_counts_df, eager=False
-        )
+        geocode_taxa_counts_lf = geocode_taxa_counts_df.lazy()
 
         # Create geocode_cluster_df for all 3 geocodes
-        geocode_cluster_df = GeocodeClusterSchema.validate(
-            pl.DataFrame(
+        geocode_cluster_df = pl.DataFrame(
                 {
                     "geocode": [1000, 2000, 3000],
                     "cluster": [0, 0, 1],
@@ -115,18 +102,15 @@ class TestClusterTaxaHeatmap(unittest.TestCase):
                 pl.col("geocode").cast(pl.UInt64),
                 pl.col("cluster").cast(pl.UInt32),
             )
-        )
 
         # Create cluster_colors_df
-        cluster_colors_df = ClusterColorSchema.validate(
-            pl.DataFrame(
+        cluster_colors_df = pl.DataFrame(
                 {
                     "cluster": [0, 1],
                     "color": ["#ff0000", "#0000ff"],
                     "darkened_color": ["#800000", "#000080"],
                 }
             ).with_columns(pl.col("cluster").cast(pl.UInt32))
-        )
 
         # Create mock distance matrix for 2 geocodes (those with taxa data)
         geocode_distance_matrix = MockGeocodeDistanceMatrix(n_geocodes=2)
@@ -150,7 +134,7 @@ class TestClusterTaxaHeatmap(unittest.TestCase):
             pl.col("neighbor_count").cast(pl.UInt32),
         )
         cluster_significant_differences_df = (
-            ClusterSignificantDifferencesSchema.validate(significant_diff_df)
+            significant_diff_df
         )
 
         # Create taxonomy_df
@@ -175,7 +159,7 @@ class TestClusterTaxaHeatmap(unittest.TestCase):
             pl.col("genus").cast(pl.Categorical),
             pl.col("gbifTaxonId").cast(pl.UInt32),
         )
-        taxonomy_df = TaxonomySchema.validate(taxonomy_df)
+        taxonomy_df = taxonomy_df
 
         # Create cluster_taxa_statistics_df
         cluster_taxa_stats_df = pl.DataFrame(
@@ -192,9 +176,7 @@ class TestClusterTaxaHeatmap(unittest.TestCase):
                 "average": pl.Float64(),
             },
         )
-        cluster_taxa_statistics_df = ClusterTaxaStatisticsSchema.validate(
-            cluster_taxa_stats_df
-        )
+        cluster_taxa_statistics_df = cluster_taxa_stats_df
 
         # This should NOT raise a ZeroDivisionError
         # Before the fix, this would fail because geocode 3000 has no taxa data
@@ -254,7 +236,7 @@ class TestClusterTaxaHeatmap(unittest.TestCase):
             pl_st.from_shapely(pl.Series(centers)).alias("center"),
             pl_st.from_shapely(pl.Series(boundaries)).alias("boundary"),
         )
-        geocode_lf = GeocodeNoEdgesSchema.validate(geocode_df, eager=False)
+        geocode_lf = geocode_df.lazy()
 
         # Create geocode_taxa_counts with data for both geocodes
         geocode_taxa_counts_df = pl.DataFrame(
@@ -268,13 +250,10 @@ class TestClusterTaxaHeatmap(unittest.TestCase):
             pl.col("taxonId").cast(pl.UInt32),
             pl.col("count").cast(pl.UInt32),
         )
-        geocode_taxa_counts_lf = GeocodeTaxaCountsSchema.validate(
-            geocode_taxa_counts_df, eager=False
-        )
+        geocode_taxa_counts_lf = geocode_taxa_counts_df.lazy()
 
         # Create geocode_cluster_df
-        geocode_cluster_df = GeocodeClusterSchema.validate(
-            pl.DataFrame(
+        geocode_cluster_df = pl.DataFrame(
                 {
                     "geocode": [1000, 2000],
                     "cluster": [0, 1],
@@ -283,18 +262,15 @@ class TestClusterTaxaHeatmap(unittest.TestCase):
                 pl.col("geocode").cast(pl.UInt64),
                 pl.col("cluster").cast(pl.UInt32),
             )
-        )
 
         # Create cluster_colors_df
-        cluster_colors_df = ClusterColorSchema.validate(
-            pl.DataFrame(
+        cluster_colors_df = pl.DataFrame(
                 {
                     "cluster": [0, 1],
                     "color": ["#ff0000", "#0000ff"],
                     "darkened_color": ["#800000", "#000080"],
                 }
             ).with_columns(pl.col("cluster").cast(pl.UInt32))
-        )
 
         # Create mock distance matrix
         geocode_distance_matrix = MockGeocodeDistanceMatrix(n_geocodes=2)
@@ -318,7 +294,7 @@ class TestClusterTaxaHeatmap(unittest.TestCase):
             pl.col("neighbor_count").cast(pl.UInt32),
         )
         cluster_significant_differences_df = (
-            ClusterSignificantDifferencesSchema.validate(significant_diff_df)
+            significant_diff_df
         )
 
         # Create taxonomy_df
@@ -343,7 +319,7 @@ class TestClusterTaxaHeatmap(unittest.TestCase):
             pl.col("genus").cast(pl.Categorical),
             pl.col("gbifTaxonId").cast(pl.UInt32),
         )
-        taxonomy_df = TaxonomySchema.validate(taxonomy_df)
+        taxonomy_df = taxonomy_df
 
         # Create cluster_taxa_statistics_df
         cluster_taxa_stats_df = pl.DataFrame(
@@ -360,9 +336,7 @@ class TestClusterTaxaHeatmap(unittest.TestCase):
                 "average": pl.Float64(),
             },
         )
-        cluster_taxa_statistics_df = ClusterTaxaStatisticsSchema.validate(
-            cluster_taxa_stats_df
-        )
+        cluster_taxa_statistics_df = cluster_taxa_stats_df
 
         # This should work without any errors
         result = create_cluster_taxa_heatmap(

--- a/test/test_cluster_taxa_statistics.py
+++ b/test/test_cluster_taxa_statistics.py
@@ -3,10 +3,7 @@ from unittest.mock import patch
 
 import polars as pl
 
-from src.dataframes.cluster_taxa_statistics import (
-    ClusterTaxaStatisticsSchema,
-    build_cluster_taxa_statistics_df,
-)
+from src.dataframes.cluster_taxa_statistics import build_cluster_taxa_statistics_df
 from test.fixtures.geocode_cluster import mock_geocode_cluster_df
 from test.fixtures.geocode_taxa_counts import mock_geocode_taxa_counts_df
 from test.fixtures.taxonomy import mock_taxonomy_lf

--- a/test/test_geocode.py
+++ b/test/test_geocode.py
@@ -1,15 +1,11 @@
 import os
 import unittest
 
-import dataframely as dy
 import polars as pl
 import polars_st as pl_st
-from dataframely.exc import ValidationError
 
 from src.dataframes.darwin_core import build_darwin_core_lf
 from src.dataframes.geocode import (
-    GeocodeNoEdgesSchema,
-    GeocodeSchema,
     build_geocode_df,
     build_geocode_lf,
     build_geocode_no_edges_lf,
@@ -34,7 +30,7 @@ class TestGeocodeSchema(unittest.TestCase):
         )
 
         # This should not raise an exception
-        geocode_df = GeocodeSchema.validate(df)
+        geocode_df = df
         self.assertIsInstance(geocode_df, pl.DataFrame)
 
     def test_build_from_darwin_core_csv(self):
@@ -106,36 +102,6 @@ class TestGeocodeSchema(unittest.TestCase):
         self.assertIn("boundary", geocode_df.columns)
         self.assertIn("is_edge", geocode_df.columns)
 
-    def test_geocode_no_edges_schema(self):
-        """Test that GeocodeNoEdgesSchema validates edge constraint"""
-        # Create a df with no edge hexagons (should pass)
-        df_no_edges = pl.DataFrame(
-            {
-                "geocode": pl.Series([1, 2], dtype=pl.UInt64),
-                "center": points_series(2),
-                "boundary": polygon_series(2),
-                "is_edge": pl.Series([False, False], dtype=pl.Boolean),
-            }
-        )
-
-        # This should not raise an exception
-        geocode_df = GeocodeNoEdgesSchema.validate(df_no_edges)
-        self.assertIsInstance(geocode_df, pl.DataFrame)
-
-        # Create a df with edge hexagons (should fail)
-        df_with_edges = pl.DataFrame(
-            {
-                "geocode": pl.Series([1, 2], dtype=pl.UInt64),
-                "center": points_series(2),
-                "boundary": polygon_series(2),
-                "is_edge": pl.Series([True, False], dtype=pl.Boolean),
-            }
-        )
-
-        # This should raise a validation error
-        with self.assertRaises(ValidationError):
-            GeocodeNoEdgesSchema.validate(df_with_edges)
-
     def test_build_geocode_no_edges_df(self):
         """Test building a GeocodeNoEdgesSchema by filtering edges"""
         # Create a GeocodeSchema df with some edge hexagons
@@ -148,8 +114,8 @@ class TestGeocodeSchema(unittest.TestCase):
             }
         )
 
-        geocode_df = GeocodeSchema.validate(df)
-        geocode_lf: dy.LazyFrame[GeocodeSchema] = geocode_df.lazy()
+        geocode_df = df
+        geocode_lf: pl.LazyFrame = geocode_df.lazy()
 
         # Build no-edges df
         no_edges_df = build_geocode_no_edges_lf(geocode_lf).collect()
@@ -172,7 +138,7 @@ class TestGeocodeSchema(unittest.TestCase):
             }
         )
 
-        geocode_df = GeocodeSchema.validate(df)
+        geocode_df = df
 
         # Test finding index of existing geocode
         index = index_of_geocode(8514355555555555, geocode_df)

--- a/test/test_geocode_neighbors.py
+++ b/test/test_geocode_neighbors.py
@@ -1,12 +1,10 @@
 import unittest
 
-import dataframely as dy
 import networkx as nx
 import polars as pl
 import polars_st as pl_st
 
 from src.dataframes.geocode_neighbors import (
-    GeocodeNeighborsSchema,
     _add_indirect_neighbor_edge,
     _df_to_graph,
     build_geocode_neighbors_df,
@@ -35,7 +33,7 @@ class TestGeocodeNeighborsSchema(unittest.TestCase):
         )
 
         # This should not raise an exception
-        neighbors_df = GeocodeNeighborsSchema.validate(df)
+        neighbors_df = df
         self.assertIsInstance(neighbors_df, pl.DataFrame)
 
     def test_graph_conversion(self):
@@ -57,7 +55,7 @@ class TestGeocodeNeighborsSchema(unittest.TestCase):
             }
         )
 
-        neighbors_df = GeocodeNeighborsSchema.validate(df)
+        neighbors_df = df
 
         # Convert to graph
         g = graph(neighbors_df)
@@ -94,7 +92,7 @@ class TestGeocodeNeighborsSchema(unittest.TestCase):
             }
         )
 
-        neighbors_df = GeocodeNeighborsSchema.validate(df)
+        neighbors_df = df
 
         # Without indirect neighbors, 3 is disconnected
         g_direct = graph(neighbors_df, include_indirect_neighbors=False)
@@ -217,8 +215,7 @@ class TestGeocodeNeighborsSchema(unittest.TestCase):
     def test_build_geocode_neighbors_no_edges_df(self):
         """Test building neighbor relationships for non-edge geocodes"""
         # Create initial neighbors df
-        neighbors_df = GeocodeNeighborsSchema.validate(
-            pl.DataFrame(
+        neighbors_df = pl.DataFrame(
                 {
                     "geocode": pl.Series([1, 2, 3, 4], dtype=pl.UInt64),
                     "direct_neighbors": pl.Series(
@@ -229,7 +226,6 @@ class TestGeocodeNeighborsSchema(unittest.TestCase):
                     ),
                 }
             )
-        )
 
         # Create non-edge geocodes df (only geocodes 2 and 4)
         no_edges_df = pl.DataFrame(

--- a/test/test_geocode_silhouette_score.py
+++ b/test/test_geocode_silhouette_score.py
@@ -3,10 +3,7 @@ import unittest
 import numpy as np
 import polars as pl
 
-from src.dataframes.geocode_silhouette_score import (
-    GeocodeSilhouetteScoreSchema,
-    build_geocode_silhouette_score_df,
-)
+from src.dataframes.geocode_silhouette_score import build_geocode_silhouette_score_df
 from src.matrices.geocode_distance import GeocodeDistanceMatrix
 from test.fixtures.geocode_cluster import mock_geocode_cluster_multi_k_df
 

--- a/test/test_geocode_taxa_counts.py
+++ b/test/test_geocode_taxa_counts.py
@@ -1,18 +1,14 @@
 import unittest
 
-import dataframely as dy
 import polars as pl
 
-from src.dataframes.geocode_taxa_counts import (
-    GeocodeTaxaCountsSchema,
-    filter_top_taxa_lf,
-)
+from src.dataframes.geocode_taxa_counts import filter_top_taxa_lf
 
 
 class TestFilterTopTaxaLf(unittest.TestCase):
     """Tests for the filter_top_taxa_lf function."""
 
-    def _create_test_data(self) -> dy.LazyFrame[GeocodeTaxaCountsSchema]:
+    def _create_test_data(self) -> pl.LazyFrame:
         """
         Creates test data with known taxa distributions.
 
@@ -39,7 +35,7 @@ class TestFilterTopTaxaLf(unittest.TestCase):
             pl.col("taxonId").cast(pl.UInt32),
             pl.col("count").cast(pl.UInt32),
         )
-        return GeocodeTaxaCountsSchema.validate(df.lazy(), eager=False)
+        return df.lazy()
 
     def test_no_filtering_when_params_none(self):
         """Test that no filtering occurs when both parameters are None."""

--- a/test/test_geojson.py
+++ b/test/test_geojson.py
@@ -3,8 +3,6 @@ import unittest
 import polars as pl
 import shapely
 
-from src.dataframes.cluster_boundary import ClusterBoundarySchema
-from src.dataframes.cluster_color import ClusterColorSchema
 from src.geojson import build_geojson_feature_collection
 
 
@@ -46,18 +44,16 @@ class TestGeojson(unittest.TestCase):
             ]
         ).with_columns(pl.col("cluster").cast(pl.UInt32()))
 
-        cluster_boundary_df = ClusterBoundarySchema.validate(cluster_boundary_df)
+        cluster_boundary_df = cluster_boundary_df
 
         actual = build_geojson_feature_collection(
             cluster_boundary_df=cluster_boundary_df,
-            cluster_colors_df=ClusterColorSchema.validate(
-                pl.DataFrame(
+            cluster_colors_df=pl.DataFrame(
                     [
                         {"cluster": 1, "color": "#ff0000", "darkened_color": "#800000"},
                         {"cluster": 2, "color": "#0000ff", "darkened_color": "#000080"},
                     ]
-                ).with_columns(pl.col("cluster").cast(pl.UInt32()))
-            ),
+                ).with_columns(pl.col("cluster").cast(pl.UInt32())),
         )
         expected = {
             "features": [

--- a/uv.lock
+++ b/uv.lock
@@ -219,24 +219,6 @@ wheels = [
 ]
 
 [[package]]
-name = "dataframely"
-version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "fsspec" },
-    { name = "numpy" },
-    { name = "polars" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/7c/a5bbc7d24de5b0a5361bc2e3ed4178759b57f32fdd97f8e3ab786881c7dd/dataframely-2.4.0.tar.gz", hash = "sha256:9dc6fb2b7d1202ce87245b26597d0c003631bb6f088e1bb82becd072b2e5155b", size = 380824, upload-time = "2025-12-23T11:42:09.401Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/5d/49ff6b71e46e8c3645a39967390d34aa721aa3c2bbcaa3554447a570e4c1/dataframely-2.4.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:19ca4cf51c94dae8f6a4e0c6b6e80cb2d48019958d80c1c9874864e03a32c78b", size = 5155855, upload-time = "2025-12-23T11:42:00.818Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/32/426735de7b5f05787d68611192569dd47d7cf9a54e2447c5eca828b2db0d/dataframely-2.4.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:3eedd4eedb546b6784cca486afedc0d5ebb728b6a371a17f12a687dd14c90dbb", size = 4801243, upload-time = "2025-12-23T11:42:02.885Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/e7/9b798279740a682023ee82d7c0bf08bc3e2882539de396f6baac2fb1d834/dataframely-2.4.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:079cae35f496160b9fd3733347767bffc58c794d4a6d0333152335ddb92e1873", size = 5032201, upload-time = "2025-12-23T11:42:04.449Z" },
-    { url = "https://files.pythonhosted.org/packages/89/41/a1bec597bcca12028fba70c53d000784a83f0e28a0a8c85452c4a549565f/dataframely-2.4.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:260762dccf719aac66d91d8f054c056f53cf4c28408ab43d5dbc84e1a0264f16", size = 5333139, upload-time = "2025-12-23T11:42:06.004Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/4a/458776c85e8ecd88c3b78dc43dbd6d792f29726276ab4910633cb56fd177/dataframely-2.4.0-cp310-abi3-win_amd64.whl", hash = "sha256:5881250b8998d01dd01a38695b0b7094ead2688c6084dc489ca7ac75f1cd0369", size = 5349255, upload-time = "2025-12-23T11:42:08.075Z" },
-]
-
-[[package]]
 name = "decorator"
 version = "5.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -294,15 +276,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/73/aa/28e40b8d6809a9b5075350a86779163f074d2b617c15d22343fce81918db/fonttools-4.61.1-cp313-cp313-win32.whl", hash = "sha256:4d7092bb38c53bbc78e9255a59158b150bcdc115a1e3b3ce0b5f267dc35dd63c", size = 2267821, upload-time = "2025-12-12T17:30:38.478Z" },
     { url = "https://files.pythonhosted.org/packages/1a/59/453c06d1d83dc0951b69ef692d6b9f1846680342927df54e9a1ca91c6f90/fonttools-4.61.1-cp313-cp313-win_amd64.whl", hash = "sha256:21e7c8d76f62ab13c9472ccf74515ca5b9a761d1bde3265152a6dc58700d895b", size = 2318169, upload-time = "2025-12-12T17:30:40.951Z" },
     { url = "https://files.pythonhosted.org/packages/c7/4e/ce75a57ff3aebf6fc1f4e9d508b8e5810618a33d900ad6c19eb30b290b97/fonttools-4.61.1-py3-none-any.whl", hash = "sha256:17d2bf5d541add43822bcf0c43d7d847b160c9bb01d15d5007d84e2217aaa371", size = 1148996, upload-time = "2025-12-12T17:31:21.03Z" },
-]
-
-[[package]]
-name = "fsspec"
-version = "2026.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d5/7d/5df2650c57d47c57232af5ef4b4fdbff182070421e405e0d62c6cdbfaa87/fsspec-2026.1.0.tar.gz", hash = "sha256:e987cb0496a0d81bba3a9d1cee62922fb395e7d4c3b575e57f547953334fe07b", size = 310496, upload-time = "2026-01-09T15:21:35.562Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl", hash = "sha256:cb76aa913c2285a3b49bdd5fc55b1d7c708d7208126b60f2eb8194fe1b4cbdcc", size = 201838, upload-time = "2026-01-09T15:21:34.041Z" },
 ]
 
 [[package]]
@@ -372,7 +345,6 @@ dependencies = [
     { name = "altair" },
     { name = "bioregion-rs" },
     { name = "black" },
-    { name = "dataframely" },
     { name = "folium" },
     { name = "geojson" },
     { name = "google-auth" },
@@ -408,7 +380,6 @@ requires-dist = [
     { name = "altair", specifier = ">=6.0.0" },
     { name = "bioregion-rs", editable = "bioregion_rs" },
     { name = "black", specifier = ">=25.1.0" },
-    { name = "dataframely", specifier = ">=1.7.6" },
     { name = "folium", specifier = ">=0.19.5" },
     { name = "geojson", specifier = ">=3.1.0" },
     { name = "google-auth", specifier = ">=2.43.0" },


### PR DESCRIPTION
## What

Drops **dataframely** entirely as a dependency. It gave us schema-typed annotations, runtime `.validate()` checks, and cache-key identity — but now that the compute stages are in Rust (which guarantees the output shapes), the runtime validation is redundant and the schema/type layer is pure overhead.

Net **−523 lines** across ~42 files, one fewer dependency.

## Mechanical changes

- `dy.DataFrame[X]` / `dy.LazyFrame[X]` annotations → plain `pl.DataFrame` / `pl.LazyFrame` (123 sites)
- **22** `.validate()` calls removed (functions return the frame directly)
- **17** `Schema` classes deleted
- `cache_parquet` now takes `cache_key: str` — it only ever hashed `Schema.__name__`, so call sites pass the name string and **cache filenames are unchanged**
- dataframely removed from `pyproject.toml`; its unused transitive `fsspec` goes too (polars reads `gs://` via its native object-store, confirmed — not fsspec)

## The two behavioral subtleties (handled)

- **Two obsolete tests deleted** — they asserted dataframely's `.validate()` *raises* on invalid input, i.e. exactly the behavior being removed.
- **One dead-code test** (`create_cluster_taxa_heatmap`, commented out in the notebook) had a latent `DataFrame`→`LazyFrame` mismatch that `.validate(df, eager=False)` was silently coercing; replaced with an explicit `.lazy()`. This was the one place `.validate()` did more than check (audit confirmed no such coercion in live pipeline code — pyright verifies).

## Verification

- `pyright` — 0 errors
- `python -m unittest` — 73 pass (75 minus the 2 obsolete validation tests)
- `harness.py` — all interop + correctness checks pass
- Full `test/sample-archive/` pipeline runs end to end (optimal k=6)

https://claude.ai/code/session_01XefuZ41iibHEgQrxWiqDjg