### PR TITLE
Port Darwin Core meta.xml parsing to Rust

### DIFF
--- a/RUST_MIGRATION_PLAN.md
+++ b/RUST_MIGRATION_PLAN.md
@@ -206,11 +206,18 @@ verified against Python in `bioregion_rs/harness.py`.
   `is_edge` matches exactly including True cases.
 - `src/types.py`, `src/constants.py`, `src/defaults.py`, `src/logging.py`,
   `src/country_bbox.py` (static bbox data) — TODO, trivial ports (done as needed).
-- `src/darwin_core_utils.py` — TODO: parquet/CSV scan + `meta.xml` parse + column renames.
-  `quick-xml` for meta; polars scan in Rust. **Note:** this is lazy/streaming + IO-bound.
-  The `lazy` feature is currently off in the crate (though it does compile with `temporal`
-  enabled — see the corrected Phase 0 finding), so it stays in Python for now.
-  (Also confirm the Rust polars build enables the cloud/object-store feature for `gs://`.)
+- `src/darwin_core_utils.py` — ✅ PARTIAL: `meta.xml` parsing ported to Rust
+  (`parse_darwin_core_meta`, `quick-xml`); `_parse_meta` now delegates to it and
+  reconstructs the `_Meta` dataclass. Verified against the sample archive
+  (`test/test_darwin_core_utils.py::TestParseMeta`). **The scan itself stays in
+  Python** (`scan_darwin_core_archive` / `build_darwin_core_raw_lf`): it is pure
+  Polars plan construction that must run in the pipeline's own Polars engine.
+  Returning the scan as a `PyLazyFrame` was investigated and rejected — pyo3-polars
+  serializes the logical plan and its `DSL_SCHEMA_HASH` only matches when the Rust
+  crate is built from the *exact same commit* as the installed pip polars wheel
+  (not merely the same version: crates.io `0.54.4` and pip `1.42.0` — both nominal
+  workspace 0.54.4 — have different DSL hashes). That lockstep coupling isn't worth
+  it for zero runtime gain, since the scan runs in the same Polars engine either way.
 - `src/dataframes/darwin_core.py` — TODO: schema + bbox filter + column select.
 - `src/dataframes/taxonomy.py` — Rust port ✅ exists (`build_taxonomy`: distinct
   (scientificName, gbifTaxonId) pairs restricted to known geocodes, each assigned a

--- a/bioregion_rs/Cargo.lock
+++ b/bioregion_rs/Cargo.lock
@@ -117,6 +117,7 @@ dependencies = [
  "polars",
  "pyo3",
  "pyo3-polars",
+ "quick-xml",
  "rand 0.9.5",
  "serde_json",
 ]
@@ -1430,6 +1431,15 @@ dependencies = [
  "polars-ffi",
  "pyo3",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/bioregion_rs/Cargo.toml
+++ b/bioregion_rs/Cargo.toml
@@ -24,20 +24,20 @@ h3o = "0.8"
 # which is subtle to get exactly right (see the module doc comment).
 kneed = "1.0"
 # We enable no polars features here (bare polars-core) because every function
-# uses only the eager DataFrame API. The `lazy` feature DOES compile with the
-# current stable toolchain when `temporal` is enabled alongside it — the
-# historical "lazy doesn't compile" note was a polars feature-unification bug
-# (enabling `strings` without `temporal` leaves `polars-expr`'s string dispatch
-# referencing the unlinked `polars_time` crate). We keep lazy off not because it
-# can't build, but because it buys nothing: the pure-Polars stages already run in
-# the Rust engine, so passing LazyFrames across the boundary would execute
-# identically. Revisit only if a stage needs plan-level interop.
+# uses only the eager DataFrame API. (Passing a LazyFrame scan plan across the
+# boundary via PyLazyFrame is not viable: pyo3-polars serializes the logical
+# plan, and its DSL_SCHEMA_HASH only matches when the Rust crate is built from
+# the exact same commit as the installed pip polars wheel — not merely the same
+# version number. So the Darwin Core scan stays in Python; only `meta.xml`
+# parsing is ported here.)
 polars = { version = "0.54.4", default-features = false }
 # `extension-module` is intentionally NOT set here: it suppresses libpython
 # linking, which breaks `cargo test`'s standalone test binary. maturin adds it at
 # wheel-build time (see [tool.maturin] features below).
 pyo3 = { version = "0.28", features = ["abi3-py313"] }
 pyo3-polars = "0.27"
+# XML parsing for Darwin Core archive meta.xml (port of _parse_meta).
+quick-xml = "0.37"
 # Already resolved transitively (polars depends on rand 0.9.5); pinned here to
 # match, for the PERMANOVA permutation test's Monte Carlo shuffling.
 rand = "0.9"

--- a/bioregion_rs/bioregion_rs.pyi
+++ b/bioregion_rs/bioregion_rs.pyi
@@ -19,6 +19,17 @@ def filter_by_bounding_box(
     lat_col: str = "decimalLatitude",
     lng_col: str = "decimalLongitude",
 ) -> pl.DataFrame: ...
+def parse_darwin_core_meta(
+    meta_path: str,
+) -> tuple[
+    str,  # core_file
+    bool,  # has_header
+    str,  # separator
+    list[str],  # columns
+    str,  # quote_char
+    str,  # encoding
+    list[tuple[str, str]],  # default_fields (term, default_value) pairs
+]: ...
 def build_geocode(
     df: pl.DataFrame,
     precision: int,

--- a/bioregion_rs/src/dataframes/darwin_core.rs
+++ b/bioregion_rs/src/dataframes/darwin_core.rs
@@ -1,0 +1,226 @@
+//! Port of `src/darwin_core_utils.py::_parse_meta` — parsing a Darwin Core
+//! archive's `meta.xml` into the parameters needed to scan its core data file.
+//!
+//! Only the XML parsing lives in Rust. The scan itself (`scan_parquet`/
+//! `scan_csv` + rename + cast) stays in Python: it is pure Polars plan
+//! construction that must run in the pipeline's own Polars engine, and passing a
+//! LazyFrame plan across the boundary is not viable (pyo3-polars serializes the
+//! logical plan, and its `DSL_SCHEMA_HASH` only matches when the Rust crate is
+//! built from the *exact same commit* as the installed pip polars wheel).
+
+use std::fs;
+use std::path::Path;
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use quick_xml::events::Event;
+use quick_xml::reader::Reader;
+
+/// Metadata parsed from a Darwin Core archive's `meta.xml`.
+/// Mirrors `src/darwin_core_utils.py::_Meta`.
+struct Meta {
+    core_file: String,
+    has_header: bool,
+    separator: String,
+    columns: Vec<String>,
+    quote_char: String,
+    encoding: String,
+    /// Insertion-ordered (term, default_value) pairs, mirroring the Python dict.
+    default_fields: Vec<(String, String)>,
+}
+
+/// Reduce a Darwin Core term URI to its bare term name, mirroring Python's
+/// `term_uri.rsplit("/", 1)[-1].rsplit("#", 1)[-1]`.
+fn term_from_uri(term_uri: &str) -> &str {
+    let after_slash = term_uri.rsplit('/').next().unwrap_or(term_uri);
+    after_slash.rsplit('#').next().unwrap_or(after_slash)
+}
+
+/// Look up an attribute (by local name) on a quick-xml start/empty element.
+fn attr(e: &quick_xml::events::BytesStart, name: &str) -> Option<String> {
+    for a in e.attributes().flatten() {
+        if a.key.local_name().as_ref() == name.as_bytes() {
+            return Some(String::from_utf8_lossy(a.value.as_ref()).into_owned());
+        }
+    }
+    None
+}
+
+/// Parse a Darwin Core archive's `meta.xml`.
+/// Mirrors `src/darwin_core_utils.py::_parse_meta`.
+fn parse_meta(meta_path: &Path) -> Result<Meta, String> {
+    let content = fs::read_to_string(meta_path).map_err(|e| format!("reading meta.xml: {e}"))?;
+    let mut reader = Reader::from_str(&content);
+    reader.config_mut().trim_text(true);
+
+    let mut in_core = false;
+    // Attributes captured from the <core> element.
+    let mut separator = ",".to_string();
+    let mut quote_char = "\"".to_string();
+    let mut encoding = "utf-8".to_string();
+    let mut has_header = false;
+
+    let mut core_file: Option<String> = None;
+    let mut fields: Vec<String> = Vec::new();
+    let mut default_fields: Vec<(String, String)> = Vec::new();
+    let mut id_index: Option<usize> = None;
+
+    // When we are inside <files>, the next <location>'s text is the core file.
+    let mut reading_location = false;
+
+    let ensure_len = |fields: &mut Vec<String>, idx: usize| {
+        if fields.len() <= idx {
+            fields.resize(idx + 1, String::new());
+        }
+    };
+
+    let handle_element = |e: &quick_xml::events::BytesStart,
+                          in_core: &mut bool,
+                          separator: &mut String,
+                          quote_char: &mut String,
+                          encoding: &mut String,
+                          has_header: &mut bool,
+                          fields: &mut Vec<String>,
+                          default_fields: &mut Vec<(String, String)>,
+                          id_index: &mut Option<usize>| {
+        match e.name().local_name().as_ref() {
+            b"core" => {
+                *in_core = true;
+                if let Some(s) = attr(e, "fieldsTerminatedBy") {
+                    *separator = if s == "\\t" { "\t".to_string() } else { s };
+                }
+                if let Some(q) = attr(e, "fieldsEnclosedBy") {
+                    *quote_char = q;
+                }
+                if let Some(enc) = attr(e, "encoding") {
+                    *encoding = enc;
+                }
+                let ignore = attr(e, "ignoreHeaderLines")
+                    .and_then(|v| v.parse::<i64>().ok())
+                    .unwrap_or(0);
+                *has_header = ignore >= 1;
+            }
+            b"field" if *in_core => {
+                if let Some(term_uri) = attr(e, "term") {
+                    let term = term_from_uri(&term_uri).to_string();
+                    if let Some(idx) = attr(e, "index").and_then(|v| v.parse::<usize>().ok()) {
+                        ensure_len(fields, idx);
+                        fields[idx] = term;
+                    } else if let Some(default_value) = attr(e, "default") {
+                        default_fields.push((term, default_value));
+                    }
+                }
+            }
+            b"id" if *in_core => {
+                *id_index = attr(e, "index").and_then(|v| v.parse::<usize>().ok());
+            }
+            _ => {}
+        }
+    };
+
+    loop {
+        match reader
+            .read_event()
+            .map_err(|e| format!("parsing meta.xml: {e}"))?
+        {
+            Event::Start(e) | Event::Empty(e) => {
+                let local = e.name().local_name().as_ref().to_vec();
+                if in_core && local == b"location" {
+                    reading_location = true;
+                }
+                handle_element(
+                    &e,
+                    &mut in_core,
+                    &mut separator,
+                    &mut quote_char,
+                    &mut encoding,
+                    &mut has_header,
+                    &mut fields,
+                    &mut default_fields,
+                    &mut id_index,
+                );
+            }
+            Event::Text(t) if reading_location => {
+                let text = t
+                    .unescape()
+                    .map_err(|e| format!("meta.xml location text: {e}"))?
+                    .trim()
+                    .to_string();
+                if !text.is_empty() {
+                    core_file = Some(text);
+                }
+            }
+            Event::End(e) => {
+                let local = e.name().local_name().as_ref().to_vec();
+                if local == b"location" {
+                    reading_location = false;
+                }
+                if local == b"core" {
+                    break;
+                }
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+
+    let core_file = core_file.ok_or_else(|| "<core> missing <files>/<location>".to_string())?;
+
+    // <id index="N"/>: if that column has no name yet, fall back to "id".
+    if let Some(idx) = id_index {
+        ensure_len(&mut fields, idx);
+        if fields[idx].is_empty() {
+            fields[idx] = "id".to_string();
+        }
+    }
+
+    // Fill any empty column names with fallback names, mirroring Python.
+    let columns: Vec<String> = fields
+        .into_iter()
+        .enumerate()
+        .map(|(i, name)| {
+            if name.is_empty() {
+                format!("col_{i}")
+            } else {
+                name
+            }
+        })
+        .collect();
+
+    Ok(Meta {
+        core_file,
+        has_header,
+        separator,
+        columns,
+        quote_char,
+        encoding,
+        default_fields,
+    })
+}
+
+/// Parse a Darwin Core archive `meta.xml`. Returns a tuple mirroring `_Meta`'s
+/// fields, which `src/darwin_core_utils.py::_parse_meta` reconstructs into the
+/// `_Meta` dataclass.
+#[pyfunction]
+pub fn parse_darwin_core_meta(
+    meta_path: String,
+) -> PyResult<(
+    String,
+    bool,
+    String,
+    Vec<String>,
+    String,
+    String,
+    Vec<(String, String)>,
+)> {
+    let meta = parse_meta(Path::new(&meta_path)).map_err(PyValueError::new_err)?;
+    Ok((
+        meta.core_file,
+        meta.has_header,
+        meta.separator,
+        meta.columns,
+        meta.quote_char,
+        meta.encoding,
+        meta.default_fields,
+    ))
+}

--- a/bioregion_rs/src/dataframes/mod.rs
+++ b/bioregion_rs/src/dataframes/mod.rs
@@ -5,6 +5,7 @@ pub mod cluster_color;
 pub mod cluster_neighbors;
 pub mod cluster_significant_differences;
 pub mod cluster_taxa_statistics;
+pub mod darwin_core;
 pub mod geocode;
 pub mod geocode_cluster;
 pub mod geocode_cluster_metrics;

--- a/bioregion_rs/src/lib.rs
+++ b/bioregion_rs/src/lib.rs
@@ -30,6 +30,10 @@ fn bioregion_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(geocode::select_geocode, m)?)?;
     m.add_function(wrap_pyfunction!(geocode::with_geocode, m)?)?;
     m.add_function(wrap_pyfunction!(geocode::filter_by_bounding_box, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        dataframes::darwin_core::parse_darwin_core_meta,
+        m
+    )?)?;
     m.add_function(wrap_pyfunction!(dataframes::geocode::build_geocode, m)?)?;
     m.add_function(wrap_pyfunction!(dataframes::taxonomy::build_taxonomy, m)?)?;
     m.add_function(wrap_pyfunction!(

--- a/src/darwin_core_utils.py
+++ b/src/darwin_core_utils.py
@@ -1,11 +1,12 @@
 """Utility functions for working with Darwin Core data."""
 
-import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Union
 
 import polars as pl
+
+import bioregion_rs
 
 
 @dataclass
@@ -111,8 +112,10 @@ def cast_taxonomic_columns(lf: pl.LazyFrame) -> pl.LazyFrame:
 def _parse_meta(meta_path: Path) -> _Meta:
     """Parse the meta.xml file and return metadata for reading the archive.
 
-    This method reads the Darwin Core archive's metafile (meta.xml) to extract
-    parameters needed to correctly parse the core data file.
+    Delegates the XML parsing to the Rust port
+    (`bioregion_rs.parse_darwin_core_meta`), which returns a tuple mirroring
+    `_Meta`'s fields, and reconstructs the `_Meta` dataclass. The scan itself
+    stays in Python (`scan_darwin_core_archive`) — only the parsing is ported.
 
     Args:
         meta_path: Path to the meta.xml file
@@ -120,100 +123,24 @@ def _parse_meta(meta_path: Path) -> _Meta:
     Returns:
         A _Meta instance containing the parsed metadata.
     """
-    tree = ET.parse(meta_path)
-    root = tree.getroot()
-
-    # Handle XML namespace if present
-    ns = {"dwc": "http://rs.tdwg.org/dwc/text/"}
-
-    # Try with namespace first, then without
-    core_elem = root.find("dwc:core", ns)
-    if core_elem is None:
-        core_elem = root.find(".//core")
-    if core_elem is None:
-        raise ValueError("meta.xml does not contain <core> element")
-
-    # file location – in <files><location>relative/path</location></files>
-    files_elem = core_elem.find(".//files")
-    if files_elem is None:
-        files_elem = core_elem.find("dwc:files", ns)
-    if files_elem is None:
-        raise ValueError("<core> missing <files>")
-
-    location_elem = files_elem.find(".//location")
-    if location_elem is None:
-        location_elem = files_elem.find("dwc:location", ns)
-    if location_elem is None or not location_elem.text:
-        raise ValueError("<files> missing <location>")
-    core_file = location_elem.text.strip()
-
-    # attributes from the <core> element, with defaults from the guide
-    separator = core_elem.get("fieldsTerminatedBy", ",")
-    if separator == "\\t":
-        separator = "\t"
-
-    quote_char = core_elem.get("fieldsEnclosedBy", '"')
-    encoding = core_elem.get("encoding", "utf-8")
-    ignore_header = int(core_elem.get("ignoreHeaderLines", "0"))
-    has_header = ignore_header >= 1
-
-    # fields and default values
-    fields: list[str] = []
-    default_fields: dict[str, str] = {}
-
-    field_elems = core_elem.findall(".//field")
-    if not field_elems:
-        field_elems = core_elem.findall("dwc:field", ns)
-
-    for field_elem in field_elems:
-        term_uri = field_elem.get("term")
-        if term_uri is None:
-            continue
-
-        term = term_uri.rsplit("/", 1)[-1].rsplit("#", 1)[-1]
-        index_str = field_elem.get("index")
-
-        if index_str is not None:
-            try:
-                idx = int(index_str)
-            except ValueError:
-                continue
-            if len(fields) <= idx:
-                fields.extend([""] * (idx - len(fields) + 1))
-            fields[idx] = term
-        else:
-            default_value = field_elem.get("default")
-            if default_value is not None:
-                default_fields[term] = default_value
-
-    # Handle <id index="0" /> element
-    id_elem = core_elem.find(".//id")
-    if id_elem is None:
-        id_elem = core_elem.find("dwc:id", ns)
-
-    if id_elem is not None:
-        idx2 = id_elem.get("index")
-        if idx2 is not None:
-            try:
-                idx = int(idx2)
-                if len(fields) <= idx:
-                    fields.extend([""] * (idx - len(fields) + 1))
-                if not fields[idx]:
-                    fields[idx] = "id"
-            except (ValueError, IndexError):
-                pass
-
-    # fill any empty column names with fallback names
-    final_fields = [name if name else f"col_{i}" for i, name in enumerate(fields)]
+    (
+        core_file,
+        has_header,
+        separator,
+        columns,
+        quote_char,
+        encoding,
+        default_fields,
+    ) = bioregion_rs.parse_darwin_core_meta(str(meta_path))
 
     return _Meta(
         core_file=core_file,
         has_header=has_header,
         separator=separator,
-        columns=final_fields,
+        columns=list(columns),
         quote_char=quote_char,
         encoding=encoding,
-        default_fields=default_fields,
+        default_fields=dict(default_fields),
     )
 
 

--- a/test/test_darwin_core_utils.py
+++ b/test/test_darwin_core_utils.py
@@ -1,11 +1,15 @@
 import unittest
+from pathlib import Path
 
 import polars as pl
 
 from src.darwin_core_utils import (
+    _parse_meta,
     build_taxon_filter,
     get_parquet_to_darwin_core_column_mapping,
 )
+
+SAMPLE_META = Path("test/sample-archive/meta.xml")
 
 
 def rename_parquet_columns_to_darwin_core(lf: pl.LazyFrame) -> pl.LazyFrame:
@@ -138,6 +142,30 @@ class TestDarwinCoreUtils(unittest.TestCase):
         self.assertIn("decimalLatitude", result_df.columns)
         self.assertIn("decimalLongitude", result_df.columns)
         self.assertEqual(len(result_df), 0)
+
+
+class TestParseMeta(unittest.TestCase):
+    """Regression tests for _parse_meta (delegates to the Rust
+    bioregion_rs.parse_darwin_core_meta port)."""
+
+    def test_parse_sample_archive_meta(self):
+        meta = _parse_meta(SAMPLE_META)
+
+        self.assertEqual(meta.core_file, "occurrence.txt")
+        self.assertTrue(meta.has_header)  # ignoreHeaderLines="1"
+        self.assertEqual(meta.separator, "\t")  # fieldsTerminatedBy="\t"
+        self.assertEqual(meta.quote_char, "")  # fieldsEnclosedBy=""
+        self.assertEqual(meta.encoding, "UTF-8")
+        # <field default="WGS84" term=".../geodeticDatum"/>
+        self.assertEqual(meta.default_fields, {"geodeticDatum": "WGS84"})
+
+        # Column 0 is <id index="0"/> which coincides with gbifID at index 0.
+        self.assertEqual(meta.columns[0], "gbifID")
+        # Known indexed terms are reduced to their bare term names.
+        self.assertIn("decimalLatitude", meta.columns)
+        self.assertIn("individualCount", meta.columns)
+        # No empty column names remain (empties become col_{i}).
+        self.assertTrue(all(name for name in meta.columns))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Ports `src/darwin_core_utils.py::_parse_meta` to Rust (`bioregion_rs.parse_darwin_core_meta`, via `quick-xml`). `_parse_meta` now delegates to it and reconstructs the `_Meta` dataclass; the ElementTree parsing is removed.

## Scope: the meta parse, not the scan

Only the `meta.xml` parsing moves to Rust. The scan itself (`scan_parquet`/`scan_csv` + rename + cast) **stays in Python** — it is pure Polars plan construction that must run in the pipeline's own Polars engine.

## Why not pass the whole scan as a PyLazyFrame

I investigated returning the full scan as a `PyLazyFrame` (the "fetch fully in Rust" version) and rejected it. pyo3-polars transfers a LazyFrame by **serializing the logical plan**, gated by a `DSL_SCHEMA_HASH` that must match exactly. Testing showed the hashes differ even at matching version numbers:

| Rust crate | pip polars | DSL hash |
|---|---|---|
| crates.io `0.54.4` | `1.37.0` | ❌ differ |
| crates.io `0.54.4` | `1.42.0` (same nominal workspace 0.54.4) | ❌ **still differ** |

The crates.io publish and the pip wheel are built from different commits, so the only way to make the boundary deserialize is to build the Rust crate from the pip wheel's **exact commit** — a brittle lockstep coupling (and, for pip 1.37.0 = workspace 0.52.0, it would force a `pyo3-polars`/`pyo3` downgrade that risks the other 20 ported functions). Not worth it for **zero runtime gain**: the scan runs in the same Polars engine either way.

So the crate keeps bare `polars-core` (no lazy/streaming/cloud feature stack); only `quick-xml` is added. The parquet/`gs://` branch is untouched — cloud auth is unaffected.

## Verification

- `parse_darwin_core_meta` matches the sample archive bit-for-bit (223 columns, tab separator, empty quote, WGS84 default) — new `test/test_darwin_core_utils.py::TestParseMeta`.
- Full unittest suite (74) green; pyright clean.
- `marimo export html notebook.py` runs end-to-end on `test/sample-archive/` through the delegated parser (valid output, real cluster/geocode data).

https://claude.ai/code/session_01XefuZ41iibHEgQrxWiqDjg